### PR TITLE
ACCUMULO-4579 Fixed hadoop config bug in accumulo-testing

### DIFF
--- a/conf/accumulo-testing.properties.example
+++ b/conf/accumulo-testing.properties.example
@@ -23,24 +23,28 @@ test.common.accumulo.instance=instance
 test.common.accumulo.username=root
 # Accumulo password
 test.common.accumulo.password=secret
+# Max memory (in bytes) each batch writer will use to buffer writes
+test.common.accumulo.bw.max.memory.bytes=100000000
+# Max latency (in milliseconds) that each batch writer will buffer data
+test.common.accumulo.bw.max.latency.ms=600000
+# Number of write thread for each batch writer
+test.common.accumulo.bw.num.threads=4
+# Number of threads used by batch scanner
+test.common.accumulo.bs.num.threads=8
+# Number of key/value entries to pull during scan
+test.common.accumulo.scanner.batch.size=1000
 # Accumulo keytab
 #test.common.accumulo.keytab=
-# Zookeeper connection string
-test.common.zookeepers=localhost:2181
+# HDFS root path. Should match 'fs.defaultFS' property in Hadoop's core-site.xml
+test.common.hdfs.root=hdfs://localhost:10000
+# YARN resource manager hostname. Should match 'yarn.resourcemanager.hostname' property in Hadoop's yarn-site.xml
+test.common.yarn.resource.manager=localhost
 # Memory (in MB) given to each container (if running in YARN)
 test.common.yarn.container.memory.mb=1024
 # Number of cores given to each container (if running in YARN)
 test.common.yarn.container.cores=1
-# Max memory (in bytes) each batch writer will use to buffer writes
-test.common.bw.max.memory.bytes=100000000
-# Max latency (in milliseconds) that each batch writer will buffer data
-test.common.bw.max.latency.ms=600000
-# Number of write thread for each batch writer
-test.common.bw.num.threads=4
-# Number of threads used by batch scanner
-test.common.bs.num.threads=8
-# Number of key/value entries to pull during scan
-test.common.scanner.batch.size=1000
+# Zookeeper connection string
+test.common.zookeepers=localhost:2181
 
 ###################################
 # Continuous ingest test properties

--- a/core/src/main/java/org/apache/accumulo/testing/core/TestProps.java
+++ b/core/src/main/java/org/apache/accumulo/testing/core/TestProps.java
@@ -42,22 +42,27 @@ public class TestProps {
   public static final String ACCUMULO_USERNAME = COMMON + "accumulo.username";
   // Accumulo password
   public static final String ACCUMULO_PASSWORD = COMMON + "accumulo.password";
+  // Max memory (in bytes) each batch writer will use to buffer writes
+  public static final String ACCUMULO_BW_MAX_MEM_BYTES = COMMON + "accumulo.bw.max.memory.bytes";
+  // Max the maximum time (in ms) each batch writer will buffer data
+  public static final String ACCUMULO_BW_MAX_LATENCY_MS = COMMON + "accumulo.bw.max.latency.ms";
+  // Number of threads each batch writer will use to write data
+  public static final String ACCUMULO_BW_NUM_THREADS = COMMON + "accumulo.bw.num.threads";
+  // Number of thread for each batch scanner
+  public static final String ACCUMULO_BS_NUM_THREADS = COMMON + "accumulo.bw.num.threads";
+  // Number of key/value entries to pull during scan
+  public static final String ACCUMULO_SCANNER_BATCH_SIZE = COMMON + "accumulo.scanner.batch.size";
   // Accumulo keytab
   public static final String ACCUMULO_KEYTAB = COMMON + "accumulo.keytab";
+  // HDFS root path. Should match 'fs.defaultFS' property in Hadoop's core-site.xml
+  public static final String HDFS_ROOT = COMMON + "hdfs.root";
+  // YARN resource manager hostname. Should match 'yarn.resourcemanager.hostname' property in
+  // Hadoop's yarn-site.xml
+  public static final String YARN_RESOURCE_MANAGER = COMMON + "yarn.resource.manager";
   // Memory (in MB) given to each YARN container
   public static final String YARN_CONTAINER_MEMORY_MB = COMMON + "yarn.container.memory.mb";
   // Number of cores given to each YARN container
   public static final String YARN_CONTAINER_CORES = COMMON + "yarn.container.cores";
-  // Max memory (in bytes) each batch writer will use to buffer writes
-  public static final String BW_MAX_MEM_BYTES = COMMON + "bw.max.memory.bytes";
-  // Max the maximum time (in ms) each batch writer will buffer data
-  public static final String BW_MAX_LATENCY_MS = COMMON + "bw.max.latency.ms";
-  // Number of threads each batch writer will use to write data
-  public static final String BW_NUM_THREADS = COMMON + "bw.num.threads";
-  // Number of thread for each batch scanner
-  public static final String BS_NUM_THREADS = COMMON + "bw.num.threads";
-  // Number of key/value entries to pull during scan
-  public static final String SCANNER_BATCH_SIZE = COMMON + "scanner.batch.size";
 
   /** Continuous ingest test properties **/
   /** Common **/

--- a/core/src/main/java/org/apache/accumulo/testing/core/continuous/ContinuousBatchWalker.java
+++ b/core/src/main/java/org/apache/accumulo/testing/core/continuous/ContinuousBatchWalker.java
@@ -54,7 +54,7 @@ public class ContinuousBatchWalker {
 
     Random r = new Random();
 
-    int scanThreads = Integer.parseInt(props.getProperty(TestProps.BS_NUM_THREADS));
+    int scanThreads = Integer.parseInt(props.getProperty(TestProps.ACCUMULO_BS_NUM_THREADS));
 
     while (true) {
       BatchScanner bs = conn.createBatchScanner(env.getAccumuloTableName(), auths, scanThreads);


### PR DESCRIPTION
* TestEnv now returns Hadoop configuration that is loaded from config files
  but expects HADOOP_PREFIX to be set in environment
* Fixed bug where Twill was being improperly configured to look in wrong
  location for shaded jar when running test application in YARN.