### PR TITLE
ACCUMULO-4717 Add checkstyle plugin to check API

### DIFF
--- a/contrib/checkstyle.xml
+++ b/contrib/checkstyle.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <module name="TreeWalker">
+    <module name="RegexpSinglelineJava">
+      <!--check that only Accumulo public APIs are imported-->
+      <property name="format" value="import\s+org[.]apache[.]accumulo[.](?:.*[.](?:impl|thrift)[.].*|(?!core|minicluster).*|core[.](?!client|data|iterators|security[.]Authorizations|security[.]ColumnVisibility|util[.]format[.]Formatter).*|core[.]data[.](?!Key|Mutation|Value|Range|Condition|ConditionalMutation|ByteSequence|PartialKey|ColumnUpdate|ArrayByteSequence).*)" />
+      <property name="ignoreComments" value="true" />
+      <property name="message" value="Accumulo non-public classes imported" />
+    </module>
+  </module>
+</module>
+

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- This was added to ensure project only uses public API. Run with the following:
+              mvn checkstyle:checkstyle
+         -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>contrib/checkstyle.xml</configLocation>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Will only run with "mvn checkstyle:checkstyle" but would be good to check usage of non public API.  This is more of a long term goal since there are a lot.