### PR TITLE
ACCUMULO-4718 Add CLASSPATH to accumulo-testing script

### DIFF
--- a/bin/accumulo-testing
+++ b/bin/accumulo-testing
@@ -70,6 +70,7 @@ fi
 
 function build_shade_jar() {
   export at_shaded_jar="$at_home/core/target/accumulo-testing-core-$at_version-shaded.jar"
+  export CLASSPATH="$at_shaded_jar:$CLASSPATH"
   if [ ! -f "$at_shaded_jar" ]; then
     echo "Building $at_shaded_jar"
     cd "$at_home" || exit 1
@@ -185,7 +186,7 @@ randomwalk_main="org.apache.accumulo.testing.core.randomwalk.Framework"
 case "$1" in
 ci-createtable)
   build_shade_jar
-  java -Dlog4j.configuration="file:$log4j_config" -cp "$at_shaded_jar" org.apache.accumulo.testing.core.continuous.CreateTable "$at_props"
+  java -Dlog4j.configuration="file:$log4j_config" org.apache.accumulo.testing.core.continuous.CreateTable "$at_props"
   ;;
 ci-local)
   if [ -z "$2" ]; then
@@ -195,7 +196,7 @@ ci-local)
   fi
   determine_app_main "$2"
   build_shade_jar
-  java -Dlog4j.configuration="file:$log4j_config" -cp "$at_shaded_jar" "$ci_main" "$at_props"
+  java -Dlog4j.configuration="file:$log4j_config" "$ci_main" "$at_props"
   ;;
 ci-yarn)
   if [ -z "$2" ]; then
@@ -229,7 +230,7 @@ rw-local)
     exit 1
   fi
   build_shade_jar
-  java -Dlog4j.configuration="file:$log4j_config" -cp "$at_shaded_jar:$HADOOP_CONF_DIR" "$randomwalk_main" "$at_props" "$2"
+  java -Dlog4j.configuration="file:$log4j_config" "$randomwalk_main" "$at_props" "$2"
   ;;
 rw-yarn)
   if [ -z "$2" ]; then

--- a/bin/accumulo-testing
+++ b/bin/accumulo-testing
@@ -229,7 +229,7 @@ rw-local)
     exit 1
   fi
   build_shade_jar
-  java -Dlog4j.configuration="file:$log4j_config" -cp "$at_shaded_jar" "$randomwalk_main" "$at_props" "$2"
+  java -Dlog4j.configuration="file:$log4j_config" -cp "$at_shaded_jar:$HADOOP_CONF_DIR" "$randomwalk_main" "$at_props" "$2"
   ;;
 rw-yarn)
   if [ -z "$2" ]; then

--- a/conf/accumulo-testing-env.sh.example
+++ b/conf/accumulo-testing-env.sh.example
@@ -20,6 +20,8 @@ test -z "$HADOOP_PREFIX" && export HADOOP_PREFIX=/path/to/hadoop
 export ACCUMULO_VERSION=`accumulo version`
 export HADOOP_VERSION=`hadoop version | head -n1 | awk '{print $2}'`
 export ZOOKEEPER_VERSION=3.4.9
+# Make sure Hadoop configuration directory is on the classpath
+export CLASSPATH=$HADOOP_PREFIX/etc/hadoop
 
 # Agitator
 # ========


### PR DESCRIPTION
The test "rw-local Bulk.xml" was throwing errors because it couldn't find the HDFS containing the files to import.  The hadoop conf wasn't on the classpath so it was defaulting to the disk "file:///" file system.  This doesn't seem to affect the rest of the tests.  Not sure if this is the best place to include HADOOP_CONF_DIR...