### PR TITLE
Clean up shaded jar conflicts

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
The Accumulo test jar depends on Hadoop test jars which have a lot of uneeded deps.  Changing the scope to `test` prevents these transitive deps from being brought into the shaded jar.  Before this change I was seeing a lot of messages like the following when building the shaded jar.  After the change there are alot less warnings about overlapping classes, and none of them are about hadoop classes.

```
[WARNING] hadoop-common-2.6.4-tests.jar, hadoop-common-2.8.4.jar define 37 overlapping classes: 
[WARNING]   - org.apache.hadoop.io.serializer.avro.AvroRecord
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos$TestProtobufRpc2Proto
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos$TestProtobufRpcProto$1
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos$1
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos$EmptyResponseProto$Builder
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos$EmptyResponseProto$1
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos$TestProtobufRpc2Proto$1
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos$EchoRequestProto$Builder
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos
[WARNING]   - org.apache.hadoop.ipc.protobuf.TestProtos$EmptyResponseProtoOrBuilder
[WARNING]   - 27 more...
[WARNING] hadoop-common-2.6.4-tests.jar, hadoop-hdfs-2.6.4-tests.jar define 1 overlapping classes: 
[WARNING]   - org.apache.hadoop.fs.shell.TestTextCommand
[WARNING] hadoop-mapreduce-client-common-2.8.4.jar, hadoop-mapreduce-client-hs-2.6.4.jar define 41 overlapping classes: 
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$HSAdminRefreshProtocolService$BlockingInterface
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$HSAdminRefreshProtocolService$BlockingStub
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshJobRetentionSettingsResponseProto$Builder
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshLogRetentionSettingsRequestProto$Builder
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshLoadedJobCacheResponseProto
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshAdminAclsRequestProtoOrBuilder
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$HSAdminRefreshProtocolService
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshLogRetentionSettingsRequestProto
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$RefreshLoadedJobCacheResponseProto$1
[WARNING]   - org.apache.hadoop.mapreduce.v2.hs.proto.HSAdminRefreshProtocolProtos$HSAdminRefreshProtocolService$Interface
```