### PR TITLE
Fixed running continuous ingest in YARN

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,6 +116,8 @@
                         <exclude>META-INF/*.SF</exclude>
                         <exclude>META-INF/*.DSA</exclude>
                         <exclude>META-INF/*.RSA</exclude>
+                        <!-- Twill 0.13 fails if shaded jar includes this directory !-->
+                        <exclude>META-INF/license/*</exclude>
                       </excludes>
                     </filter>
                   </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <hadoop.version>3.0.3</hadoop.version>
     <zookeeper.version>3.4.9</zookeeper.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <twill.version>0.12.1</twill.version>
+    <twill.version>0.13.0</twill.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <formatter.config>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</formatter.config>


### PR DESCRIPTION
* Excluded license directory from shaded jar to prevent
  Twill from failing
* Upgraded Twill to 0.13 and made minor improvement to code.