### PR TITLE
Improvements made for 2.0.0-alpha-2 CI testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,18 @@ run in Docker:
 3. Multiple containers can also be run (if you have [Docker Swarm] enabled):
 
    ```bash
+   # the following can be used to get the image on all nodes if you do not have a registry.
+   for HOST in node1 node2 node3; do
+     docker save accumulo-testing | ssh -C $HOST docker load &
+   done
+
    docker service create --network="host" --replicas 2 --name ci accumulo-testing cingest ingest
    ```
 
 ## Random walk test
 
 The random walk test generates client behavior on an Apache Accumulo instance by randomly walking a
-graph of client operations. 
+graph of client operations.
 
 Before running random walk, review the `test.common.*` properties in `accumulo-testing.properties`
 file. A test module must also be specified. See the [modules] directory for a list of available ones.
@@ -101,12 +106,12 @@ First, run the command below to create an Accumulo table for the continuous inge
 table is set by the property `test.ci.common.accumulo.table` (its value defaults to `ci`) in the file
 `accumulo-testing.properties`:
 
-          ./bin/cingest createtable
+          ./bin/cingest createtable {-o <prop>=<value>}
 
 The continuous ingest tests have several applications that start a local application which will run
 continuously until you stop using `ctrl-c`:
 
-          ./bin/cingest <application>
+          ./bin/cingest <application> {-o <prop>=<value>}
 
 Below is a list of available continuous ingest applications. You should run the `ingest` application
 first to add data to your table.
@@ -130,6 +135,9 @@ latest nodes inserted.
 table. This MapReduce job will write out an entry for every entry in the table (except for ones
 created by the MapReduce job itself). Stop ingest before running this MapReduce job. Do not run more
 than one instance of this MapReduce job concurrently against a table.
+
+Checkout [ingest-test.md](docs/ingest-test.md) for pointers on running a long
+running ingest and verification test.
 
 ## Agitator
 
@@ -208,7 +216,7 @@ function stop_cluster {
 ```
 
 An example script for [Uno] is provided.  To use this do the following and set
-`UNO_HOME` after copying. 
+`UNO_HOME` after copying.
 
     cp conf/cluster-control.sh.uno conf/cluster-control.sh
 

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ First, run the command below to create an Accumulo table for the continuous inge
 table is set by the property `test.ci.common.accumulo.table` (its value defaults to `ci`) in the file
 `accumulo-testing.properties`:
 
-          ./bin/cingest createtable {-o <prop>=<value>}
+          ./bin/cingest createtable {-o test.<prop>=<value>}
 
 The continuous ingest tests have several applications that start a local application which will run
 continuously until you stop using `ctrl-c`:
 
-          ./bin/cingest <application> {-o <prop>=<value>}
+          ./bin/cingest <application> {-o test.<prop>=<value>}
 
 Below is a list of available continuous ingest applications. You should run the `ingest` application
 first to add data to your table.

--- a/bin/agitator
+++ b/bin/agitator
@@ -29,10 +29,10 @@ Possible commands:
 EOF
 }
 
-if [ -f "$at_home/conf/accumulo-testing-env.sh" ]; then
-  . "$at_home"/conf/accumulo-testing-env.sh
+if [ -f "$at_home/conf/env.sh" ]; then
+  . "$at_home"/conf/env.sh
 else
-  . "$at_home"/conf/accumulo-testing-env.sh.example
+  . "$at_home"/conf/env.sh.example
 fi
 
 function start_agitator() {

--- a/bin/cingest
+++ b/bin/cingest
@@ -21,7 +21,7 @@ at_home=$( cd "$( dirname "$bin_dir" )" && pwd )
 function print_usage() {
   cat <<EOF
 
-Usage: cingest <application>
+Usage: cingest <application> {-o <test prop>=<value>}
 
 Available applications:
 
@@ -83,12 +83,12 @@ case "$1" in
   verify|moru)
     if [ ! -z $HADOOP_HOME ]; then
       export HADOOP_USE_CLIENT_CLASSLOADER=true
-      "$HADOOP_HOME"/bin/yarn jar "$TEST_JAR_PATH" "$ci_main" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
+      "$HADOOP_HOME"/bin/yarn jar "$TEST_JAR_PATH" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
     else
       echo "Hadoop must be installed and HADOOP_HOME must be set!"
       exit 1
     fi
     ;;
   *)
-    java -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
+    java -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
 esac

--- a/bin/cingest
+++ b/bin/cingest
@@ -21,7 +21,7 @@ at_home=$( cd "$( dirname "$bin_dir" )" && pwd )
 function print_usage() {
   cat <<EOF
 
-Usage: cingest <application> {-o <test prop>=<value>}
+Usage: cingest <application> {-o test.<prop>=<value>}
 
 Available applications:
 

--- a/conf/accumulo-testing.properties.example
+++ b/conf/accumulo-testing.properties.example
@@ -44,6 +44,8 @@ test.ci.common.auths=
 # ------
 # Number of entries each ingest client should write
 test.ci.ingest.client.entries=9223372036854775807
+# Flush batch writer after this many entries.
+test.ci.ingest.entries.flush=1000000
 # Minimum random row to generate
 test.ci.ingest.row.min=0
 # Maximum random row to generate
@@ -57,7 +59,8 @@ test.ci.ingest.max.cq=32767
 test.ci.ingest.visibilities=
 # Checksums will be generated during ingest if set to true
 test.ci.ingest.checksum=true
-# Enables periodic pausing of ingest
+# Enables periodic pausing of ingest. Pause checks are only done after a flush. To write small
+# amounts of data and then pause, set pause.wait.max and entries.flush small.
 test.ci.ingest.pause.enabled=false
 # Minimum wait between ingest pauses (in seconds)
 test.ci.ingest.pause.wait.min=120
@@ -90,7 +93,7 @@ test.ci.scanner.entries=5000
 # Verify
 # -----
 # Maximum number of mapreduce mappers
-test.ci.verify.max.maps=64
+test.ci.verify.max.maps=4096
 # Number of mapreduce reducers
 test.ci.verify.reducers=64
 # Perform the verification directly on the files while the table is offline

--- a/docs/ingest-test.md
+++ b/docs/ingest-test.md
@@ -24,7 +24,7 @@ docker service create --network="host" --replicas $NUM_NODES --name ci \
 # seen with continuous writes.
 #
 for i in $(seq 1 $NUM_NODES); do
-  TABLE="cip-$i"
+  TABLE="cip_$i"
   docker run --network="host" accumulo-testing cingest createtable \
      -o test.ci.common.accumulo.table=$TABLE \
      -o test.ci.common.accumulo.num.tablets=$(( $NUM_NODES * 4 ))
@@ -43,7 +43,7 @@ done
 # https://github.com/apache/accumulo/issues/854
 #
 for FLUSH_SIZE in 97 101 997 1009 ; do
-  TABLE="cip-small-$FLUSH_SIZE"
+  TABLE="cip_small_$FLUSH_SIZE"
   docker run --network="host" accumulo-testing cingest createtable \
      -o test.ci.common.accumulo.table=$TABLE \
      -o test.ci.common.accumulo.num.tablets=$(( $NUM_NODES * 2 ))

--- a/docs/ingest-test.md
+++ b/docs/ingest-test.md
@@ -1,0 +1,85 @@
+# Running a long continuous ingest test
+
+Running continuous ingest for long periods on a cluster is a good way to
+validate an Accumulo release.  This document outlines one possible way to do
+that.  The commands below show how to start different types of ingest into 
+multiple tables.  These commands assume the docker image was created for 
+accumulo-testing and that docker swarm is available on the cluster.
+
+```bash
+# Number of nodes in cluster
+NUM_NODES=10
+
+# Start lots of processes writing to a single table as fast as possible
+docker run --network="host" accumulo-testing cingest createtable
+docker service create --network="host" --replicas $NUM_NODES --name ci \
+   accumulo-testing cingest ingest \
+   -o test.ci.ingest.pause.enabled=false
+
+# Write data with pauses.  Should cause tablets to not have data in some write
+# ahead logs.  But there is still enough write pressure to cause minor
+# compactions.
+#
+# Some of the write ahead log recovery bugs fixed in 1.9.1 and 1.9.2 were not
+# seen with continuous writes.
+#
+for i in $(seq 1 $NUM_NODES); do
+  TABLE="cip-$i"
+  docker run --network="host" accumulo-testing cingest createtable \
+     -o test.ci.common.accumulo.table=$TABLE \
+     -o test.ci.common.accumulo.num.tablets=$(( $NUM_NODES * 4 ))
+  docker service create --network="host" --replicas 1 --name $TABLE \
+     accumulo-testing cingest ingest \
+     -o test.ci.common.accumulo.table=$TABLE \
+     -o test.ci.ingest.pause.enabled=true
+done
+
+# Write very small amounts of data with long pauses in between.  Should cause
+# data to be spread across lots of write ahead logs.  So little data is written
+# that minor compactions may not happen because of writes.  If Accumulo does
+# nothing then this will result in tablet servers having lots of write ahead
+# logs.
+#
+# https://github.com/apache/accumulo/issues/854
+#
+for FLUSH_SIZE in 97 101 997 1009 ; do
+  TABLE="cip-small-$FLUSH_SIZE"
+  docker run --network="host" accumulo-testing cingest createtable \
+     -o test.ci.common.accumulo.table=$TABLE \
+     -o test.ci.common.accumulo.num.tablets=$(( $NUM_NODES * 2 ))
+  docker service create --network="host" --replicas 1 --name $TABLE \
+     accumulo-testing cingest ingest \
+     -o test.ci.common.accumulo.table=$TABLE \
+     -o test.ci.ingest.pause.enabled=true \
+     -o test.ci.ingest.pause.wait.min=1 \
+     -o test.ci.ingest.pause.wait.max=3 \
+     -o test.ci.ingest.entries.flush=$FLUSH_SIZE
+done
+```
+
+After starting the ingest, consider starting the agitator.  Testing with and
+without agitation is valuable.  Let the ingest run for a period of 12 to 36
+hours. Then stop it as follows.
+
+
+```bash
+# stop the agitator if started
+
+# stop all docker services (assuming its only ingest started above, otherwise do not run)
+docker service rm $(docker service ls -q)
+```
+
+After ingest stops verify the data.
+
+```bash
+# run verification map reduce jobs
+mkdir -p logs
+accumulo shell -u root -p secret -e tables | grep ci | while read table ; do
+  nohup ./bin/cingest verify \
+      -o test.ci.common.accumulo.table=$table \
+      -o test.ci.verify.output.dir=/tmp/ci-verify-$table \
+          &> logs/verify_$table.log &
+done
+```
+
+

--- a/docs/ingest-test.md
+++ b/docs/ingest-test.md
@@ -77,7 +77,7 @@ mkdir -p logs
 accumulo shell -u root -p secret -e tables | grep ci | while read table ; do
   nohup ./bin/cingest verify \
       -o test.ci.common.accumulo.table=$table \
-      -o test.ci.verify.output.dir=/tmp/ci-verify-$table \
+      -o test.ci.verify.output.dir=/tmp/$table-verify \
           &> logs/verify_$table.log &
 done
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <description>Testing tools for Apache Accumulo</description>
 
   <properties>
-    <accumulo.version>2.0.0-alpha-2</accumulo.version>
+    <accumulo.version>2.0.0-SNAPSHOT</accumulo.version>
     <hadoop.version>3.0.3</hadoop.version>
     <zookeeper.version>3.4.9</zookeeper.version>
     <slf4j.version>1.7.21</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <description>Testing tools for Apache Accumulo</description>
 
   <properties>
-    <accumulo.version>2.0.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>2.0.0-alpha-2</accumulo.version>
     <hadoop.version>3.0.3</hadoop.version>
     <zookeeper.version>3.4.9</zookeeper.version>
     <slf4j.version>1.7.21</slf4j.version>

--- a/src/main/java/org/apache/accumulo/testing/TestProps.java
+++ b/src/main/java/org/apache/accumulo/testing/TestProps.java
@@ -82,6 +82,8 @@ public class TestProps {
   public static final String CI_INGEST_PAUSE_DURATION_MIN = CI_INGEST + "pause.duration.min";
   // Maximum pause duration (in seconds)
   public static final String CI_INGEST_PAUSE_DURATION_MAX = CI_INGEST + "pause.duration.max";
+  // Amount of data to write before flushing. Pause checks are only done after flush.
+  public static final String CI_INGEST_FLUSH_ENTRIES = CI_INGEST + "entries.flush";
 
   /** Batch Walker **/
   // Sleep time between batch scans (in ms)

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousEnv.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousEnv.java
@@ -13,8 +13,8 @@ class ContinuousEnv extends TestEnv {
 
   private List<Authorizations> authList;
 
-  ContinuousEnv(String testPropsPath, String clientPropsPath) {
-    super(testPropsPath, clientPropsPath);
+  ContinuousEnv(String[] args) {
+    super(args);
   }
 
   /**

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousMoru.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousMoru.java
@@ -23,13 +23,13 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.hadoop.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.hadoop.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.testing.TestProps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -113,11 +113,7 @@ public class ContinuousMoru extends Configured implements Tool {
   @Override
   public int run(String[] args) throws Exception {
 
-    if (args.length != 2) {
-      System.err.println("Usage: ContinuousMoru <testPropsPath> <clientPropsPath>");
-      System.exit(-1);
-    }
-    ContinuousEnv env = new ContinuousEnv(args[0], args[1]);
+    ContinuousEnv env = new ContinuousEnv(args);
 
     Job job = Job.getInstance(getConf(),
         this.getClass().getSimpleName() + "_" + System.currentTimeMillis());
@@ -151,11 +147,7 @@ public class ContinuousMoru extends Configured implements Tool {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 2) {
-      System.err.println("Usage: ContinuousMoru <testPropsPath> <clientPropsPath>");
-      System.exit(-1);
-    }
-    ContinuousEnv env = new ContinuousEnv(args[0], args[1]);
+    ContinuousEnv env = new ContinuousEnv(args);
     int res = ToolRunner.run(env.getHadoopConfiguration(), new ContinuousMoru(), args);
     if (res != 0)
       System.exit(res);

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
@@ -26,10 +26,10 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.testing.TestProps;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
@@ -140,21 +140,19 @@ public class ContinuousVerify extends Configured implements Tool {
 
   @Override
   public int run(String[] args) throws Exception {
-    if (args.length != 2) {
-      System.err.println("Usage: ContinuousVerify <testPropsPath> <clientPropsPath>");
-      System.exit(-1);
-    }
-    ContinuousEnv env = new ContinuousEnv(args[0], args[1]);
+
+    ContinuousEnv env = new ContinuousEnv(args);
+
+    String tableName = env.getAccumuloTableName();
 
     Job job = Job.getInstance(getConf(),
-        this.getClass().getSimpleName() + "_" + System.currentTimeMillis());
+        this.getClass().getSimpleName() + "_"+ tableName + "_" + System.currentTimeMillis());
     job.setJarByClass(this.getClass());
 
     job.setInputFormatClass(AccumuloInputFormat.class);
 
     boolean scanOffline = Boolean.parseBoolean(env
         .getTestProperty(TestProps.CI_VERIFY_SCAN_OFFLINE));
-    String tableName = env.getAccumuloTableName();
     int maxMaps = Integer.parseInt(env.getTestProperty(TestProps.CI_VERIFY_MAX_MAPS));
     int reducers = Integer.parseInt(env.getTestProperty(TestProps.CI_VERIFY_REDUCERS));
     String outputDir = env.getTestProperty(TestProps.CI_VERIFY_OUTPUT_DIR);
@@ -202,11 +200,7 @@ public class ContinuousVerify extends Configured implements Tool {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 2) {
-      System.err.println("Usage: ContinuousVerify <testPropsPath> <clientPropsPath>");
-      System.exit(-1);
-    }
-    ContinuousEnv env = new ContinuousEnv(args[0], args[1]);
+    ContinuousEnv env = new ContinuousEnv(args);
 
     int res = ToolRunner.run(env.getHadoopConfiguration(), new ContinuousVerify(), args);
     if (res != 0)


### PR DESCRIPTION
Added ability to set test options on command line. This makes running different
types of ingest from the same docker image easy.  Without this change a new
docker image would need to be created for each different ingest type.

Documented commands for running a long running ingest test.

Made the ingest flush size configurable.  This made it possible to write really
small amounts of data and then pause.  This changes makes testing
for the problem in apache/accumulo#854 possible.

Added docs for how to copy docker image to other nodes if you don't have
a repository handy.