### PR TITLE
Update checkstyle to use import-control for API checking

### DIFF
--- a/contrib/checkstyle.xml
+++ b/contrib/checkstyle.xml
@@ -17,12 +17,16 @@
 <module name="Checker">
   <property name="charset" value="UTF-8"/>
   <module name="TreeWalker">
+    <!--check that only Accumulo public APIs are imported-->
+    <module name="ImportControl">
+      <property name="file" value="contrib/import-control.xml"/>
+    </module>
+    <!-- the following module was for accumulo 1.9 
     <module name="RegexpSinglelineJava">
-      <!--check that only Accumulo public APIs are imported-->
-      <property name="format" value="import\s+org\.apache\.accumulo\.(.*\.(impl|thrift|crypto)\..*|(?!core|minicluster|testing).*|core\.(?!client|data|security).*)"/>
+      <property name="format" value="import\s+org\.apache\.accumulo\.(.*\.(impl|thrift|crypto)\..*|(?!core|minicluster|testing|hadoop).*|core\.(?!client|data|security|iterators).*)"/>
       <property name="ignoreComments" value="true" />
       <property name="message" value="Accumulo non-public classes imported" />
-    </module>
+    </module> -->
   </module>
 </module>
 

--- a/contrib/checkstyle.xml
+++ b/contrib/checkstyle.xml
@@ -21,12 +21,6 @@
     <module name="ImportControl">
       <property name="file" value="contrib/import-control.xml"/>
     </module>
-    <!-- the following module was for accumulo 1.9 
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="import\s+org\.apache\.accumulo\.(.*\.(impl|thrift|crypto)\..*|(?!core|minicluster|testing|hadoop).*|core\.(?!client|data|security|iterators).*)"/>
-      <property name="ignoreComments" value="true" />
-      <property name="message" value="Accumulo non-public classes imported" />
-    </module> -->
   </module>
 </module>
 

--- a/contrib/import-control.xml
+++ b/contrib/import-control.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE import-control PUBLIC
+    "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/import_control_1_4.dtd">
+<import-control pkg="org.apache.accumulo.testing" strategyOnMismatch="allowed">
+    <allow pkg="org.apache.accumulo.core.client"/>
+    <allow pkg="org.apache.accumulo.core.data"/>
+    <allow pkg="org.apache.accumulo.core.security"/>
+    <allow pkg="org.apache.accumulo.core.iterators"/>
+    <allow pkg="org.apache.accumulo.minicluster"/>
+    <allow pkg="org.apache.accumulo.hadoop.mapreduce"/>
+    <!-- exceptions for testing -->
+    <allow class="org.apache.accumulo.core.conf.Property.*" regex="true"/>
+    <allow pkg="org.apache.accumulo.testing"/>
+    <!-- disallow everything else coming from accumulo -->
+    <disallow pkg="org.apache.accumulo"/>
+</import-control>

--- a/contrib/import-control.xml
+++ b/contrib/import-control.xml
@@ -33,11 +33,6 @@
     <allow pkg="org.apache.accumulo.core.conf"/>
 
     <!-- TODO refactor code to remove the following exceptions -->
-    <allow pkg="org.apache.accumulo.core.cli"/> 
-    <allow pkg="org.apache.accumulo.core.util"/>
-    <allow pkg="org.apache.accumulo.core.trace"/>
-    <allow pkg="org.apache.accumulo.core.file"/>
-    <allow pkg="org.apache.accumulo.core.clientImpl"/>
     <allow class="org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType"/>
     <allow class="org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException"/>
     <allow class="org.apache.accumulo.core.metadata.MetadataTable"/>
@@ -45,6 +40,26 @@
     <allow class="org.apache.accumulo.core.spi.scan.HintScanPrioritizer"/>
     <allow class="org.apache.accumulo.hadoopImpl.mapreduce.lib.MapReduceClientOnRequiredTable"/>
     <allow class="org.apache.accumulo.core.crypto.CryptoServiceFactory"/>
+    <allow class="org.apache.accumulo.core.clientImpl.ClientContext"/>
+    <allow class="org.apache.accumulo.core.clientImpl.TabletServerBatchWriter"/>
+    <allow class="org.apache.accumulo.core.file.FileOperations"/>
+    <allow class="org.apache.accumulo.core.file.FileSKVWriter"/>
+    <allow class="org.apache.accumulo.core.file.rfile.RFile"/>
+    <allow class="org.apache.accumulo.core.util.SimpleThreadPool"/>
+    <allow class="org.apache.accumulo.core.util.FastFormat"/>
+    <allow class="org.apache.accumulo.core.cli.ClientOnRequiredTable"/>
+    <allow class="org.apache.accumulo.core.cli.BatchScannerOpts"/>
+    <allow class="org.apache.accumulo.core.cli.ClientOnDefaultTable"/>
+    <allow class="org.apache.accumulo.core.cli.ClientOpts.TimeConverter"/>
+    <allow class="org.apache.accumulo.core.cli.Help"/>
+    <allow class="org.apache.accumulo.core.cli.BatchWriterOpts"/>
+    <allow class="org.apache.accumulo.core.cli.ClientOpts"/>
+    <allow class="org.apache.accumulo.core.cli.ScannerOpts"/>
+    <allow class="org.apache.accumulo.core.util.Pair"/>
+    <allow class="org.apache.accumulo.core.trace.Trace"/>
+    <allow class="org.apache.accumulo.core.trace.TraceSamplers"/>
+    <allow class="org.apache.accumulo.core.trace.Span"/>
+    <allow class="org.apache.accumulo.core.trace.DistributedTrace"/>
     <!-- End TODO section -->
 
     <!-- disallow everything else coming from accumulo -->

--- a/contrib/import-control.xml
+++ b/contrib/import-control.xml
@@ -16,16 +16,37 @@
 <!DOCTYPE import-control PUBLIC
     "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
     "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<!-- This checkstyle rule is configured to ensure only use of Accumulo API -->
 <import-control pkg="org.apache.accumulo.testing" strategyOnMismatch="allowed">
+    <!-- allow this package -->
+    <allow pkg="org.apache.accumulo.testing"/>
+    <!-- API packages -->
     <allow pkg="org.apache.accumulo.core.client"/>
     <allow pkg="org.apache.accumulo.core.data"/>
     <allow pkg="org.apache.accumulo.core.security"/>
     <allow pkg="org.apache.accumulo.core.iterators"/>
     <allow pkg="org.apache.accumulo.minicluster"/>
     <allow pkg="org.apache.accumulo.hadoop.mapreduce"/>
+
     <!-- exceptions for testing -->
-    <allow class="org.apache.accumulo.core.conf.Property.*" regex="true"/>
-    <allow pkg="org.apache.accumulo.testing"/>
+    <allow pkg="org.apache.accumulo.core.conf"/>
+
+    <!-- TODO refactor code to remove the following exceptions -->
+    <allow pkg="org.apache.accumulo.core.cli"/> 
+    <allow pkg="org.apache.accumulo.core.util"/>
+    <allow pkg="org.apache.accumulo.core.trace"/>
+    <allow pkg="org.apache.accumulo.core.file"/>
+    <allow pkg="org.apache.accumulo.core.clientImpl"/>
+    <allow class="org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType"/>
+    <allow class="org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException"/>
+    <allow class="org.apache.accumulo.core.metadata.MetadataTable"/>
+    <allow class="org.apache.accumulo.core.replication.ReplicationTable"/>
+    <allow class="org.apache.accumulo.core.spi.scan.HintScanPrioritizer"/>
+    <allow class="org.apache.accumulo.hadoopImpl.mapreduce.lib.MapReduceClientOnRequiredTable"/>
+    <allow class="org.apache.accumulo.core.crypto.CryptoServiceFactory"/>
+    <!-- End TODO section -->
+
     <!-- disallow everything else coming from accumulo -->
     <disallow pkg="org.apache.accumulo"/>
 </import-control>

--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,7 @@
         </executions>
       </plugin>
       <plugin>
-        <!-- This was added to ensure project only uses public API. Run with the following:
-              mvn checkstyle:check
-         -->
+        <!-- This was added to ensure project only uses public API -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
@@ -134,6 +132,14 @@
               <version>8.17</version>
             </dependency>
 	</dependencies>
+	<executions>
+          <execution>
+            <id>check-style</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -119,14 +119,21 @@
       </plugin>
       <plugin>
         <!-- This was added to ensure project only uses public API. Run with the following:
-              mvn checkstyle:checkstyle
+              mvn checkstyle:check
          -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.0.0</version>
         <configuration>
           <configLocation>contrib/checkstyle.xml</configLocation>
         </configuration>
+	<dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.17</version>
+            </dependency>
+	</dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/IsolatedScan.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/IsolatedScan.java
@@ -30,10 +30,12 @@ import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.PeekingIterator;
 import org.apache.accumulo.testing.randomwalk.RandWalkEnv;
 import org.apache.accumulo.testing.randomwalk.State;
 import org.apache.accumulo.testing.randomwalk.Test;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
 
 public class IsolatedScan extends Test {
 
@@ -53,7 +55,7 @@ public class IsolatedScan extends Test {
           Authorizations.EMPTY)));
 
       while (iter.hasNext()) {
-        PeekingIterator<Entry<Key,Value>> row = new PeekingIterator<>(iter.next());
+        PeekingIterator<Entry<Key,Value>> row = Iterators.peekingIterator(iter.next());
         Entry<Key,Value> kv = null;
         if (row.hasNext())
           kv = row.peek();


### PR DESCRIPTION
This should be easier to maintain than the regex (at least for 2.0) and the output is a lot more helpful:
<pre>
[ERROR] src/main/java/org/apache/accumulo/testing/stress/ScanOpts.java:[19,1] (imports) ImportControl: Disallowed import - org.apache.accumulo.core.cli.ClientOnDefaultTable.
[ERROR] src/main/java/org/apache/accumulo/testing/stress/WriteOptions.java:[19,1] (imports) ImportControl: Disallowed import - org.apache.accumulo.core.cli.ClientOnDefaultTable.
[ERROR] src/main/java/org/apache/accumulo/testing/stress/Write.java:[19,1] (imports) ImportControl: Disallowed import - org.apache.accumulo.core.cli.BatchWriterOpts.

</pre>
VS the old output
<pre>
[ERROR] src/main/java/org/apache/accumulo/testing/stress/ScanOpts.java:[19] (regexp) RegexpSinglelineJava: Accumulo non-public classes imported
[ERROR] src/main/java/org/apache/accumulo/testing/stress/WriteOptions.java:[19] (regexp) RegexpSinglelineJava: Accumulo non-public classes imported
[ERROR] src/main/java/org/apache/accumulo/testing/stress/Write.java:[19] (regexp) RegexpSinglelineJava: Accumulo non-public classes imported
</pre>

There are a lot of crazy things you can do with the [import-control checkstyle rule](http://checkstyle.sourceforge.net/config_imports.html#ImportControl) but this was the best I could come up with... 

I also upgraded the checkstyle plugin to 3.0.0 and made it use the latest checkstyle dependency 8.17.