### PR TITLE
Improve yield+scan exec performance test

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/performance/tests/ProbabilityFilter.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/tests/ProbabilityFilter.java
@@ -1,28 +1,16 @@
 package org.apache.accumulo.testing.performance.tests;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.BiPredicate;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.IteratorEnvironment;
-import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public class ProbabilityFilter extends YieldingFilter {
-
-  private double matchProbability;
-
   @Override
-  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
-      IteratorEnvironment env) throws IOException {
-    super.init(source, options, env);
-    this.matchProbability = Double.parseDouble(options.get("probability"));
-  }
-
-  @Override
-  protected BiPredicate<Key, Value> createPredicate() {
+  protected BiPredicate<Key, Value> createPredicate(Map<String,String> options) {
+    double matchProbability = Double.parseDouble(options.get("probability"));
     Random rand = new Random();
     return (k,v) -> rand.nextDouble() < matchProbability;
   }


### PR DESCRIPTION
Before this commit the filters running in the background had a very low
chance of returning data.  This did not execercise the use case of an
iterator returning data very slowly.  Returning data very slowly results
in slowly filling a buffer.  The test was modified to run the filter
scans with multiple probabilites which causes data to return with
different velocities.  Also the yield filter was modfied to support
yielding across returning a key/value.

The design of the yield filter was improved so that subclasses do not
have to override init().