### PR TITLE
Fix #83 Add hadoop conf to CLASSPATH for defaultFS

### DIFF
--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -1,3 +1,4 @@
+#! /usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -22,6 +23,15 @@ export HADOOP_HOME="${HADOOP_HOME:-/path/to/hadoop}"
 export ACCUMULO_HOME="${ACCUMULO_HOME:-/path/to/accumulo}"
 ## Path to Accumulo client properties
 export ACCUMULO_CLIENT_PROPS="$ACCUMULO_HOME/conf/accumulo-client.properties"
+
+# Add HADOOP conf directory to CLASSPATH, if set (for defaultFS in core-site.xml, etc.)
+if [[ -n $HADOOP_CONF_DIR ]]; then
+  if [[ -z $CLASSPATH ]]; then
+    export CLASSPATH="$HADOOP_CONF_DIR"
+  else
+    export CLASSPATH="$CLASSPATH:$HADOOP_CONF_DIR"
+  fi
+fi
 
 # Configuration
 # =============


### PR DESCRIPTION
Ensure test client code has core-site.xml on its class path so that when
client code calls "new Configuration()" (for example, to qualify HDFS
paths without a scheme), it will use the fs.defaultFS to qualify them.

This fixes issues in bulk import test code that does not properly
qualify Paths as hdfs:// paths, and instead assumes file:// incorrectly.