### PR TITLE
Removed SNAPSHOT from version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-testing</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>Apache Accumulo Testing</name>
   <description>Testing tools for Apache Accumulo</description>
   <properties>


### PR DESCRIPTION
The first version line still contained SNAPSHOT in it. The Jar file would in turn contain SNAPSHOT in its name. 