### PR TITLE
Fixes issue #114, incorrect auths used by scanners and walkers

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousEnv.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousEnv.java
@@ -27,7 +27,7 @@ public class ContinuousEnv extends TestEnv {
         authList = Collections.singletonList(Authorizations.EMPTY);
       } else {
         authList = new ArrayList<>();
-        for (String a : authValue.split("|")) {
+        for (String a : authValue.split("\\|")) {
           authList.add(new Authorizations(a.split(",")));
         }
       }


### PR DESCRIPTION
Fixed authValue.split("|") call in ContinuousEnv.java.
It was not considering | as a metacharacter in regex used by split
added escape character "\\" in the split function call as authValue.split("\\|")