### PR TITLE
Support extra Java options

### DIFF
--- a/bin/cingest
+++ b/bin/cingest
@@ -92,5 +92,5 @@ case "$1" in
     fi
     ;;
   *)
-    java -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
+    java $JAVA_OPTS -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
 esac

--- a/bin/gcs
+++ b/bin/gcs
@@ -61,5 +61,4 @@ esac
 
 export CLASSPATH="$TEST_JAR_PATH:$HADOOP_API_JAR:$HADOOP_RUNTIME_JAR:$CLASSPATH"
 
-java -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"
-
+java $JAVA_OPTS -Dlog4j.configuration="file:$TEST_LOG4J" "$ci_main" "${@:2}" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS"

--- a/bin/performance
+++ b/bin/performance
@@ -68,7 +68,7 @@ case "$1" in
     fi
     # don't start unless we can find the class provided
     found=false
-    CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config" ${perf_pkg}.ListTests | while read -r test_class; do
+    CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config" ${perf_pkg}.ListTests | while read -r test_class; do
       if [[ "$test_class" == "$3" ]]; then
         found=true
       fi
@@ -80,30 +80,30 @@ case "$1" in
     fi
     mkdir -p "$2"
     start_cluster
-    CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config" ${perf_pkg}.ListTests | while read -r test_class; do
+    CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config" ${perf_pkg}.ListTests | while read -r test_class; do
       if [[ -z $3 || $test_class == *$3* ]]; then
         echo "Running test $test_class"
         pt_tmp=$(mktemp -d -t accumulo_pt_XXXXXXX)
         setup_accumulo
         get_config_file accumulo.properties "$pt_tmp"
-        CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.MergeSiteConfig "$test_class" "$pt_tmp"
+        CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.MergeSiteConfig "$test_class" "$pt_tmp"
         put_config_file "$pt_tmp/accumulo.properties"
         put_server_code "$at_home/target/accumulo-testing-$at_version.jar"
         start_accumulo
         get_config_file accumulo-client.properties "$pt_tmp"
-        CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.PerfTestRunner "$pt_tmp/accumulo-client.properties" "$test_class" "$(get_version 'ACCUMULO')" "$2"
+        CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.PerfTestRunner "$pt_tmp/accumulo-client.properties" "$test_class" "$(get_version 'ACCUMULO')" "$2"
       fi
     done
     stop_cluster
     ;;
   compare)
-    CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.Compare "$2" "$3"
+    CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.Compare "$2" "$3"
     ;;
   csv)
-    CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.Csv "${@:2}"
+    CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.Csv "${@:2}"
     ;;
   list)
-    CLASSPATH="$CP" java -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.ListTests
+    CLASSPATH="$CP" java $JAVA_OPTS -Dlog4j.configuration="file:$log4j_config"  ${perf_pkg}.ListTests
     ;;
   *)
     echo "Unknown command : $1"

--- a/bin/rwalk
+++ b/bin/rwalk
@@ -41,4 +41,4 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-java -Dlog4j.configuration="file:$TEST_LOG4J" "$randomwalk_main" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS" "$1"
+java $JAVA_OPTS -Dlog4j.configuration="file:$TEST_LOG4J" "$randomwalk_main" "$TEST_PROPS" "$ACCUMULO_CLIENT_PROPS" "$1"


### PR DESCRIPTION
Interjects an extra $JAVA_OPTS environemnt variable wherever Java is being launched. This adds flexibility for the user to define extra options, for example Xmx.