### PR TITLE
update test with correct API call

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/conditional/Init.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/conditional/Init.java
@@ -53,7 +53,7 @@ public class Init extends Test {
     for (int i = 0; i < numBanks; i++)
       banks.add(i);
     // shuffle for case when multiple threads are adding banks
-    Collections.shuffle(banks, (Random) state.get("rand"));
+    Collections.shuffle(banks, (Random) state.getRandom());
 
     ConditionalWriter cw = (ConditionalWriter) state.get("cw");
 


### PR DESCRIPTION
The randomwalk test with Conditional.xml module failed for me with `RuntimeException: State does not contain rand`.
The Setup class never sets a state object with 'rand' as a key but does set a Random object (using setRandom()) and can be retrieved using getRandom() API