### PR TITLE
Exclude log4j2 jars from shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,8 @@
                     <excludes>
                       <exclude>org.apache.accumulo:accumulo-native</exclude>
                       <exclude>org.apache.hadoop:*</exclude>
+                      <exclude>org.apache.logging.log4j:log4j-api:jar:</exclude>
+                      <exclude>org.apache.logging.log4j:log4j-1.2-api:jar:</exclude>
                     </excludes>
                   </artifactSet>
                   <filters>


### PR DESCRIPTION
* This will fix log4j logging with the current version

This is only a stop gap until we can upgrade accumulo-testing to Log4j2.  It may be that we just do that instead of this PR.