### PR TITLE
Fixes #135. Fix build errors due recent changes in accumulo

### DIFF
--- a/contrib/import-control.xml
+++ b/contrib/import-control.xml
@@ -35,13 +35,13 @@
 
     <!-- exceptions for testing -->
     <allow pkg="org.apache.accumulo.core.conf"/>
+    <allow class="org.apache.accumulo.core.util.threads.ThreadPools"/>
 
     <!-- TODO refactor code to remove the following exceptions -->
     <allow class="org.apache.accumulo.core.metadata.MetadataTable"/>
     <allow class="org.apache.accumulo.core.replication.ReplicationTable"/>
     <allow class="org.apache.accumulo.core.spi.scan.HintScanPrioritizer"/>
     <allow class="org.apache.accumulo.core.clientImpl.TabletServerBatchWriter"/>
-    <allow class="org.apache.accumulo.core.util.SimpleThreadPool"/>
     <allow class="org.apache.accumulo.core.util.FastFormat"/>
     <allow class="org.apache.accumulo.core.util.Pair"/>
     <allow class="org.apache.accumulo.core.trace.Trace"/>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache Accumulo Testing</name>
   <description>Testing tools for Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.0.0</accumulo.version>
+    <accumulo.version>2.1.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>${project.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <hadoop.version>3.2.0</hadoop.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
@@ -43,7 +43,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.accumulo.core.util.SimpleThreadPool;
+import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -224,7 +224,7 @@ public class Module extends Node {
       fixture.setUp(state, env);
     }
 
-    ExecutorService service = new SimpleThreadPool(1, "RandomWalk Runner");
+    ExecutorService service = ThreadPools.createFixedThreadPool(1, "RandomWalk Runner", false);
 
     try {
       Node initNode = getNode(initNodeId);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.iterators.LongCombiner;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
-import org.apache.accumulo.core.util.SimpleThreadPool;
+import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.testing.randomwalk.RandWalkEnv;
 import org.apache.accumulo.testing.randomwalk.State;
 import org.apache.accumulo.testing.randomwalk.Test;
@@ -60,8 +60,8 @@ public class Setup extends Test {
     state.set("fs", FileSystem.get(env.getHadoopConfiguration()));
     state.set("bulkImportSuccess", "true");
     BulkPlusOne.counter.set(0l);
-
-    ThreadPoolExecutor e = new SimpleThreadPool(MAX_POOL_SIZE, "bulkImportPool");
+    ThreadPoolExecutor e = ThreadPools.createFixedThreadPool(MAX_POOL_SIZE, "bulkImportPool",
+        false);
     state.set("pool", e);
   }
 

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
@@ -84,14 +84,14 @@ public class Config extends Test {
 			s(Property.TSERV_WAL_BLOCKSIZE, 1024 * 1024,
 					1024 * 1024 * 1024 * 10L),
 			s(Property.TSERV_WORKQ_THREADS, 1, 10),
-			s(Property.MASTER_BULK_THREADPOOL_SIZE, 1, 10),
-			s(Property.MASTER_BULK_RETRIES, 1, 10),
-			s(Property.MASTER_BULK_TIMEOUT, 10, 600),
-			s(Property.MASTER_FATE_THREADPOOL_SIZE, 1, 100),
-			s(Property.MASTER_RECOVERY_DELAY, 0, 100),
-			s(Property.MASTER_LEASE_RECOVERY_WAITING_PERIOD, 0, 10),
-			s(Property.MASTER_THREADCHECK, 100, 10000),
-			s(Property.MASTER_MINTHREADS, 1, 200),};
+			s(Property.MANAGER_BULK_THREADPOOL_SIZE, 1, 10),
+			s(Property.MANAGER_BULK_RETRIES, 1, 10),
+			s(Property.MANAGER_BULK_TIMEOUT, 10, 600),
+			s(Property.MANAGER_FATE_THREADPOOL_SIZE, 1, 100),
+			s(Property.MANAGER_RECOVERY_DELAY, 0, 100),
+			s(Property.MANAGER_LEASE_RECOVERY_WAITING_PERIOD, 0, 10),
+			s(Property.MANAGER_THREADCHECK, 100, 10000),
+			s(Property.MANAGER_MINTHREADS, 1, 200),};
 
 	Setting[] tableSettings = {
 			s(Property.TABLE_MAJC_RATIO, 1, 10),

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Replication.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Replication.java
@@ -17,7 +17,7 @@
 package org.apache.accumulo.testing.randomwalk.concurrent;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static org.apache.accumulo.core.conf.Property.MASTER_REPLICATION_SCAN_INTERVAL;
+import static org.apache.accumulo.core.conf.Property.MANAGER_REPLICATION_SCAN_INTERVAL;
 import static org.apache.accumulo.core.conf.Property.REPLICATION_NAME;
 import static org.apache.accumulo.core.conf.Property.REPLICATION_PEERS;
 import static org.apache.accumulo.core.conf.Property.REPLICATION_PEER_PASSWORD;
@@ -74,7 +74,7 @@ public class Replication extends Test {
     iOps.setProperty(REPLICATION_PEER_USER.getKey() + instName, env.getAccumuloUserName());
     iOps.setProperty(REPLICATION_PEER_PASSWORD.getKey() + instName, env.getAccumuloPassword());
     // Tweak some replication parameters to make the replication go faster
-    iOps.setProperty(MASTER_REPLICATION_SCAN_INTERVAL.getKey(), "1s");
+    iOps.setProperty(MANAGER_REPLICATION_SCAN_INTERVAL.getKey(), "1s");
     iOps.setProperty(REPLICATION_WORK_ASSIGNMENT_SLEEP.getKey(), "1s");
     iOps.setProperty(REPLICATION_WORK_PROCESSOR_DELAY.getKey(), "1s");
     iOps.setProperty(REPLICATION_WORK_PROCESSOR_PERIOD.getKey(), "1s");


### PR DESCRIPTION
closes #135. 

Based on changes in accumulo-2.1.0: 
Changes property names to the respective Manager ones. Also, SimpleThreadPool was removed so that has been changed to ThreadPools. 