### PR TITLE
 Update CI to use Compaction Planner

### DIFF
--- a/conf/accumulo-testing.properties
+++ b/conf/accumulo-testing.properties
@@ -42,7 +42,10 @@ test.ci.common.auths=
 # Accumulo tserver properties to set when creating a table
 test.ci.common.accumulo.server.props=\
 tserver.compaction.major.service.cs1.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \
-tserver.compaction.major.service.cs1.planner.opts.executors=[{"name":"small","type":"internal","maxSize":"32M","numThreads":4},{"name":"medium","type":"internal","maxSize":"128M","numThreads":2},{"name":"large","type":"external","queue":"DCQ1"}]
+tserver.compaction.major.service.cs1.planner.opts.executors=\
+[{"name":"small","type":"internal","maxSize":"16M","numThreads":8},\
+{"name":"medium","type":"internal","maxSize":"128M","numThreads":4},\
+{"name":"large","type":"internal","numThreads":2}]
   
 # Accumulo table properties to set when creating table
 test.ci.common.accumulo.table.props=\

--- a/conf/accumulo-testing.properties
+++ b/conf/accumulo-testing.properties
@@ -39,12 +39,15 @@ test.ci.common.accumulo.num.tablets=20
 # Optional authorizations that if specified will be randomly selected by scanners and walkers
 # Format: a,b|a,b,c|c
 test.ci.common.auths=
+# Accumulo tserver properties to set when creating a table
+test.ci.common.accumulo.server.props=\
+tserver.compaction.major.service.cs1.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \
+tserver.compaction.major.service.cs1.planner.opts.executors=[{"name":"small","type":"internal","maxSize":"32M","numThreads":4},{"name":"medium","type":"internal","maxSize":"128M","numThreads":2},{"name":"large","type":"external","queue":"DCQ1"}]
+  
 # Accumulo table properties to set when creating table
 test.ci.common.accumulo.table.props=\
-table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.strategies.BasicCompactionStrategy \
-table.majc.compaction.strategy.opts.filter.size=250M \
-table.majc.compaction.strategy.opts.large.compress.threshold=100M \
-table.majc.compaction.strategy.opts.large.compress.type=gz
+table.compaction.dispatcher=org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher \
+table.compaction.dispatcher.opts.service=cs1
 
 # Ingest
 # ------

--- a/src/main/java/org/apache/accumulo/testing/TestProps.java
+++ b/src/main/java/org/apache/accumulo/testing/TestProps.java
@@ -56,9 +56,10 @@ public class TestProps {
   // Number of tablets that should exist in Accumulo table when created
   public static final String CI_COMMON_ACCUMULO_NUM_TABLETS = CI_COMMON + "accumulo.num.tablets";
   // Optional authorizations (in CSV format) that if specified will be
-  // randomly selected by scanners
-  // and walkers
+  // randomly selected by scanners and walkers
   public static final String CI_COMMON_AUTHS = CI_COMMON + "auths";
+  // Tserver props to set when a table is created
+  public static final String CI_COMMON_SERVER_PROPS = CI_COMMON + "accumulo.server.props";
 
   /** Ingest **/
   // Number of entries each ingest client should write

--- a/src/main/java/org/apache/accumulo/testing/TestProps.java
+++ b/src/main/java/org/apache/accumulo/testing/TestProps.java
@@ -59,7 +59,7 @@ public class TestProps {
   // randomly selected by scanners and walkers
   public static final String CI_COMMON_AUTHS = CI_COMMON + "auths";
   // Tserver props to set when a table is created
-  public static final String CI_COMMON_SERVER_PROPS = CI_COMMON + "accumulo.server.props";
+  public static final String CI_COMMON_ACCUMULO_SERVER_PROPS = CI_COMMON + "accumulo.server.props";
 
   /** Ingest **/
   // Number of entries each ingest client should write

--- a/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
@@ -59,13 +59,14 @@ public class CreateTable {
 
       // retrieve and set tserver props
       Map<String,String> props = getProps(env, TestProps.CI_COMMON_ACCUMULO_SERVER_PROPS);
-      props.forEach((k, v) -> {
-        try {
-          client.instanceOperations().setProperty(k, v);
-        } catch (AccumuloException | AccumuloSecurityException e) {
-          e.printStackTrace();
+      try {
+        for (Map.Entry<String,String> entry : props.entrySet()) {
+          client.instanceOperations().setProperty(entry.getKey(), entry.getValue());
         }
-      });
+      } catch (AccumuloException | AccumuloSecurityException e) {
+        log.error("Failed to set tserver props");
+        throw new Exception(e);
+      }
 
       SortedSet<Text> splits = new TreeSet<>();
       final int numSplits = numTablets - 1;

--- a/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
@@ -58,7 +58,7 @@ public class CreateTable {
       }
 
       // retrieve and set tserver props
-      Map<String,String> props = getProps(env, TestProps.CI_COMMON_SERVER_PROPS);
+      Map<String,String> props = getProps(env, TestProps.CI_COMMON_ACCUMULO_SERVER_PROPS);
       props.forEach((k, v) -> {
         try {
           client.instanceOperations().setProperty(k, v);


### PR DESCRIPTION
Fixes #145 

Changes were added to allow the compaction planner configuration to be changed via the properties file.

The current settings were taken from [an example](https://accumulo.apache.org/blog/2021/07/08/external-compactions.html#configuration-1) and may not be optimal for this specific test. Not sure what is best for this case and recommendations are welcome.