### PR TITLE
Replace use of the deprecated `newInstance()` method

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/scalability/Run.java
+++ b/src/main/java/org/apache/accumulo/testing/scalability/Run.java
@@ -80,7 +80,7 @@ public class Run {
 
     ScaleTest test = (ScaleTest) Class
         .forName(String.format("org.apache.accumulo.test.scalability.%s", opts.testId))
-        .newInstance();
+        .getDeclaredConstructor().newInstance();
 
     test.init(scaleProps, testProps, opts.numTabletServers);
 


### PR DESCRIPTION
While working on #150 I noticed the following while building:
```
[WARNING] /home/dgarguilo/github/accumulo-testing/src/main/java/org/apache/accumulo/testing/scalability/Run.java:[83,9] newInstance() in java.lang.Class has been deprecated
```

It looks like `newInstance()` has been deprecated and replaced by `getDeclaredConstructor().newInstance()`.
