### PR TITLE
Added check for existing output directory in /bin/cingest verify

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
@@ -52,9 +52,11 @@ import org.slf4j.LoggerFactory;
 public class ContinuousVerify extends Configured implements Tool {
   public static final VLongWritable DEF = new VLongWritable(-1);
 
+  private static final Logger log = LoggerFactory.getLogger(ContinuousVerify.class);
+
   public static class CMapper extends Mapper<Key,Value,LongWritable,VLongWritable> {
 
-    private static final Logger log = LoggerFactory.getLogger(CMapper.class);
+    private static final Logger cMapperLogger = LoggerFactory.getLogger(CMapper.class);
     private final LongWritable row = new LongWritable();
     private final LongWritable ref = new LongWritable();
     private final VLongWritable vrow = new VLongWritable();
@@ -72,9 +74,9 @@ public class ContinuousVerify extends Configured implements Tool {
       } catch (ContinuousWalk.BadChecksumException bce) {
         context.getCounter(Counts.CORRUPT).increment(1L);
         if (corrupt < 1000) {
-          log.error("Bad checksum : " + key);
+          cMapperLogger.error("Bad checksum : " + key);
         } else if (corrupt == 1000) {
-          log.error("Too many bad checksums, not printing anymore!");
+          cMapperLogger.error("Too many bad checksums, not printing anymore!");
         }
         corrupt++;
         return;
@@ -190,7 +192,7 @@ public class ContinuousVerify extends Configured implements Tool {
 
       Path outputPath = new Path(outputDir + "/" + job.getJobName());
       TextOutputFormat.setOutputPath(job, outputPath);
-      System.out.println("Results from this run will be stored in " + outputPath);
+      log.info("Results from this run will be stored in {}", outputPath);
 
       job.waitForCompletion(true);
 

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
@@ -52,11 +52,9 @@ import org.slf4j.LoggerFactory;
 public class ContinuousVerify extends Configured implements Tool {
   public static final VLongWritable DEF = new VLongWritable(-1);
 
-  private static final Logger log = LoggerFactory.getLogger(ContinuousVerify.class);
-
   public static class CMapper extends Mapper<Key,Value,LongWritable,VLongWritable> {
 
-    private static final Logger cMapperLogger = LoggerFactory.getLogger(CMapper.class);
+    private static final Logger log = LoggerFactory.getLogger(CMapper.class);
     private final LongWritable row = new LongWritable();
     private final LongWritable ref = new LongWritable();
     private final VLongWritable vrow = new VLongWritable();
@@ -74,9 +72,9 @@ public class ContinuousVerify extends Configured implements Tool {
       } catch (ContinuousWalk.BadChecksumException bce) {
         context.getCounter(Counts.CORRUPT).increment(1L);
         if (corrupt < 1000) {
-          cMapperLogger.error("Bad checksum : " + key);
+          log.error("Bad checksum : " + key);
         } else if (corrupt == 1000) {
-          cMapperLogger.error("Too many bad checksums, not printing anymore!");
+          log.error("Too many bad checksums, not printing anymore!");
         }
         corrupt++;
         return;

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
@@ -197,19 +197,18 @@ public class ContinuousVerify extends Configured implements Tool {
 
       try {
         job.waitForCompletion(true);
-
-        // this will occur if verify is run without removing the output directory between runs
       } catch (FileAlreadyExistsException e) {
-        FileSystem fs = FileSystem.get(env.getHadoopConfiguration());
+        // this will occur if verify is run without removing the output directory between runs
 
         // if the exception occurred from something other than the output directory already
         // existing, throw the exception
+        FileSystem fs = FileSystem.get(env.getHadoopConfiguration());
         if (!fs.exists(outputPath)) {
           throw e;
         }
 
         String prompt = "\nOutput directory " + outputPath
-            + " already exists. Do you want to delete it and re-run verify? [y/n] : ";
+            + " already exists. Do you want to delete it and re-run verify? [y/n]: ";
         String decision = System.console().readLine(prompt);
 
         if (decision.length() == 1 && decision.toLowerCase(Locale.ENGLISH).charAt(0) == 'y') {

--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousVerify.java
@@ -58,9 +58,9 @@ public class ContinuousVerify extends Configured implements Tool {
   public static class CMapper extends Mapper<Key,Value,LongWritable,VLongWritable> {
 
     private static final Logger log = LoggerFactory.getLogger(CMapper.class);
-    private LongWritable row = new LongWritable();
-    private LongWritable ref = new LongWritable();
-    private VLongWritable vrow = new VLongWritable();
+    private final LongWritable row = new LongWritable();
+    private final LongWritable ref = new LongWritable();
+    private final VLongWritable vrow = new VLongWritable();
 
     private long corrupt = 0;
 
@@ -102,7 +102,7 @@ public class ContinuousVerify extends Configured implements Tool {
   }
 
   public static class CReducer extends Reducer<LongWritable,VLongWritable,Text,Text> {
-    private ArrayList<Long> refs = new ArrayList<>();
+    private final ArrayList<Long> refs = new ArrayList<>();
 
     @Override
     public void reduce(LongWritable key, Iterable<VLongWritable> values, Context context)


### PR DESCRIPTION
Fixes #92 

* ~~Added a check to see if the output directory exists. If so, the user is prompted to see if they want the directory to be removed and the verify job rerun.~~
* EDIT: Create a unique output directory to store the output of each run of `/bin/cingest verify`
* Made applicable variables final. Unrelated to the issue addressed but thought I would improve the file while I was already making changes