### PR TITLE
Update readme and add comments to RandomCachedLookupsPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ applied. The example below will run just the DurabilityWriteSpeedPT.
 
     ./bin/performance run <output dir> DurabilityWriteSpeedPT
 
+Some performance tests alter the system properties of the cluster it is trying to test on. These
+may require fine-tuning in order to work on some hardware.
+
 There are some utilities for working with the JSON result files, run the `performance` script
 with no options to see them.
 

--- a/src/main/java/org/apache/accumulo/testing/performance/tests/RandomCachedLookupsPT.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/tests/RandomCachedLookupsPT.java
@@ -68,6 +68,9 @@ public class RandomCachedLookupsPT implements PerformanceTest {
     siteCfg.put(Property.TSERV_MINTHREADS.getKey(), "256");
     siteCfg.put(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getKey(), "32");
     siteCfg.put(Property.TABLE_DURABILITY.getKey(), "flush");
+
+    // Verify the size of the caches below are smaller than the java heap size given to the tserver.
+    // The heap size can be found and changed in accumulo-env.sh.
     siteCfg.put(Property.TSERV_DATACACHE_SIZE.getKey(), "2G");
     siteCfg.put(Property.TSERV_INDEXCACHE_SIZE.getKey(), "1G");
 
@@ -203,11 +206,11 @@ public class RandomCachedLookupsPT implements PerformanceTest {
 
     reportBuilder.info("create", t2 - t1, ms, "Time to create table");
     reportBuilder.info("split", t3 - t2, ms, "Time to split table");
-    reportBuilder.info("write", 4 * numRows, t4 - t3, "entries/sec",
+    reportBuilder.info("write", 4L * numRows, t4 - t3, "entries/sec",
         "Rate at which data are written");
-    reportBuilder.info("compact", 4 * numRows, t5 - t4, "entries/sec",
+    reportBuilder.info("compact", 4L * numRows, t5 - t4, "entries/sec",
         "Rate at which tables are compacted");
-    reportBuilder.info("fullScan", 4 * numRows, t6 - t5, "entries/sec",
+    reportBuilder.info("fullScan", 4L * numRows, t6 - t5, "entries/sec",
         "Rate at which full table scans take place");
   }
 


### PR DESCRIPTION
Some performance tests alter the system configuration of a cluster which may cause some tests to fail if run on inadequate hardware. RandomCachedLookupsPT specifically failed if the cache sizes were larger than the java heap size of the tserver. These additions aim to inform the user that some tests may require changes to certain property values in order to run.

RandomCachedLookupsPT also had a few warnings that I fixed and included in this PR. 

Closes #159.