### PR TITLE
Ignore ReplicaitonRandomWalkIT from maven verify build

### DIFF
--- a/src/test/java/org/apache/accumulo/testing/randomwalk/ReplicationRandomWalkIT.java
+++ b/src/test/java/org/apache/accumulo/testing/randomwalk/ReplicationRandomWalkIT.java
@@ -26,8 +26,10 @@ import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.testing.randomwalk.concurrent.Replication;
 import org.apache.hadoop.conf.Configuration;
 import org.easymock.EasyMock;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("Replication ITs are not stable and not currently maintained")
 public class ReplicationRandomWalkIT extends ConfigurableMacBase {
 
   @Override


### PR DESCRIPTION
Fixes #164. 

This IT has been unstable for some time and verify often fails for accumulo-testing. This follows the same approach as the replication ITs in accumulo. 