### PR TITLE
Fix build warnings in a few classes due to deprication

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/performance/impl/MergeSiteConfig.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/impl/MergeSiteConfig.java
@@ -32,7 +32,7 @@ public class MergeSiteConfig {
     Path confFile = Paths.get(args[1], "accumulo.properties");
 
     PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class)
-        .newInstance();
+        .getDeclaredConstructor().newInstance();
 
     Properties props = new Properties();
 

--- a/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
@@ -41,7 +41,7 @@ public class PerfTestRunner {
     String accumuloVersion = args[2];
     String outputDir = args[3];
 
-    PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class)
+    PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class).getDeclaredConstructor()
         .newInstance();
 
     AccumuloClient client = Accumulo.newClient().from(clientProps).build();

--- a/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
@@ -41,7 +41,8 @@ public class PerfTestRunner {
     String accumuloVersion = args[2];
     String outputDir = args[3];
 
-    PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class).getDeclaredConstructor()
+    PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class)
+        .getDeclaredConstructor().newInstance();
         .newInstance();
 
     AccumuloClient client = Accumulo.newClient().from(clientProps).build();

--- a/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
+++ b/src/main/java/org/apache/accumulo/testing/performance/impl/PerfTestRunner.java
@@ -43,7 +43,6 @@ public class PerfTestRunner {
 
     PerformanceTest perfTest = Class.forName(className).asSubclass(PerformanceTest.class)
         .getDeclaredConstructor().newInstance();
-        .newInstance();
 
     AccumuloClient client = Accumulo.newClient().from(clientProps).build();
 

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Framework.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Framework.java
@@ -72,7 +72,7 @@ public class Framework {
     if (id.endsWith(".xml")) {
       node = new Module(id);
     } else {
-      node = (Test) Class.forName(id).newInstance();
+      node = (Test) Class.forName(id).getDeclaredConstructor().newInstance();
     }
     nodes.put(id, node);
     return node;

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
@@ -548,7 +548,8 @@ public class Module extends Node {
     nodelist = d.getDocumentElement().getElementsByTagName("fixture");
     if (nodelist.getLength() > 0) {
       Element fixtureEl = (Element) nodelist.item(0);
-      fixture = (Fixture) Class.forName(getFullName(fixtureEl.getAttribute("id"))).newInstance();
+      fixture = (Fixture) Class.forName(getFullName(fixtureEl.getAttribute("id")))
+          .getDeclaredConstructor().newInstance();
     }
 
     // parse initial node


### PR DESCRIPTION
There were a few build warnings due to Class.newInstance() being deprecated. I am not 100% sure if this is the most ideal fix but it does remove those warnings. 