### PR TITLE
Fix  module-info warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,6 @@
                   <artifactSet>
                     <excludes>
                       <exclude>org.apache.accumulo:accumulo-native</exclude>
-                      <exclude>org.apache.zookeeper*</exclude>
                       <exclude>org.apache.hadoop:*</exclude>
                       <exclude>log4j:*</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,7 @@
                   <artifactSet>
                     <excludes>
                       <exclude>org.apache.accumulo:accumulo-native</exclude>
+                      <exclude>org.apache.zookeeper*</exclude>
                       <exclude>org.apache.hadoop:*</exclude>
                       <exclude>log4j:*</exclude>
                     </excludes>
@@ -407,6 +408,7 @@
                     <filter>
                       <artifact>*:*</artifact>
                       <excludes>
+                        <exclude>module-info.class</exclude>
                         <exclude>META-INF/*.SF</exclude>
                         <exclude>META-INF/*.DSA</exclude>
                         <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
A couple more warnings in the build. 

```
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
```
Currently ran into a bug with this section
<del>
WARNING] zookeeper-3.4.14.jar, zookeeper-jute-3.5.9.jar define 101 overlapping classes: 
[WARNING]   - org.apache.zookeeper.proto.GetMaxChildrenRequest
[WARNING]   - org.apache.jute.compiler.JavaGenerator
[WARNING]   - org.apache.jute.XmlInputArchive$XMLParser
[WARNING]   - org.apache.jute.CsvInputArchive$1
[WARNING]   - org.apache.zookeeper.proto.SetACLRequest
[WARNING]   - org.apache.jute.compiler.JLong
[WARNING]   - org.apache.zookeeper.server.quorum.QuorumPacket
[WARNING]   - org.apache.zookeeper.proto.SetSASLRequest
[WARNING]   - org.apache.zookeeper.data.Id
[WARNING]   - org.apache.zookeeper.proto.SyncRequest
[WARNING]   - 91 more...
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/

</del>