### PR TITLE
Update zookeeper version to fix Overlapping warning

### DIFF
--- a/conf/env.sh
+++ b/conf/env.sh
@@ -61,7 +61,7 @@ fi
 # Versions set below will be what is included in the shaded jar
 ACCUMULO_VERSION="$("$ACCUMULO_HOME"/bin/accumulo version | grep -v 'DEBUG')"; export ACCUMULO_VERSION
 HADOOP_VERSION="$(hadoop version | head -n1 | awk '{print $2}')"; export HADOOP_VERSION
-export ZOOKEEPER_VERSION=3.4.14
+export ZOOKEEPER_VERSION=3.7.0
 # Path to shaded test jar
 at_home=$( cd "$( dirname "$conf_dir" )" && pwd )
 export TEST_JAR_PATH="${at_home}/target/accumulo-testing-shaded.jar"


### PR DESCRIPTION
Build script was still exporting zookeeper version 3.14.4. Updating that to version 3.7.0 fixes the overlap warning while building.