### PR TITLE
bump log4j version from 2.4 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <disruptor.version>3.4.4</disruptor.version>
     <eclipseFormatterStyle>${project.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <hadoop.version>3.2.0</hadoop.version>
-    <log4j2.version>2.4</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
This only bumps the log4j version - unsure if additional changes are required to migrate from 2.4 --> 2.16.0