### PR TITLE
Eliminate possible race condition in `agitator stop` script

### DIFF
--- a/bin/agitator
+++ b/bin/agitator
@@ -157,10 +157,13 @@ function start_agitator() {
 
 function stop_agitator() {
   [[ -n $AGITATOR_USER ]] || AGITATOR_USER=$(whoami)
-  echo "Stopping all processes matching 'sleep' as $AGITATOR_USER"
-  pkill -f sleep 2>/dev/null
-  echo "Stopping all processes matching 'agitator' as $AGITATOR_USER"
-  pkill -f agitator 2>/dev/null
+  echo "Stopping all processes in the same process group as 'agitator' as $AGITATOR_USER"
+  ## get process ids of agitator processes then just keep the first
+  agitator_pid=$(pgrep -f agitator | head -1)
+  ## get the group process id of the agitator process then clear whitespace
+  group_pid=$(ps -p "${agitator_pid}" -o pgid= | xargs)
+  ## kill all processes in process group, should be all agitators and their sleep processes
+  kill -- -"${group_pid}"
 }
 
 function parse_fail() {

--- a/bin/agitator
+++ b/bin/agitator
@@ -158,12 +158,12 @@ function start_agitator() {
 function stop_agitator() {
   [[ -n $AGITATOR_USER ]] || AGITATOR_USER=$(whoami)
   echo "Stopping all processes in the same process group as 'agitator' as $AGITATOR_USER"
-  ## get process ids of agitator processes then just keep the first
-  agitator_pid=$(pgrep -f agitator | head -1)
-  ## get the group process id of the agitator process then clear whitespace
-  group_pid=$(ps -p "${agitator_pid}" -o pgid= | xargs)
-  ## kill all processes in process group, should be all agitators and their sleep processes
-  kill -- -"${group_pid}"
+  ## get process ids of all agitator processes (return 1 if none found)
+  local agitator_pids=(); agitator_pids=($(pgrep -f "agitator start")) || return 1
+  ## get the group process ids of all agitator processes
+  local group_pids=(); group_pids=($(ps -o pgid= -p "${agitator_pids[@]}"))
+  ## kill all processes in the process groups (should include agitators and their sleep processes)
+  kill -- "${group_pids[@]/#/-}"
 }
 
 function parse_fail() {

--- a/bin/agitator
+++ b/bin/agitator
@@ -157,7 +157,7 @@ function start_agitator() {
 
 function stop_agitator() {
   [[ -n $AGITATOR_USER ]] || AGITATOR_USER=$(whoami)
-  echo "Stopping all processes in the same process group as 'agitator' as $AGITATOR_USER"
+  echo "Stopping all processes in the same process group as 'agitator' as user $AGITATOR_USER"
   ## get process ids of all agitator processes (return 1 if none found)
   local agitator_pids=(); agitator_pids=($(pgrep -f "agitator start")) || return 1
   ## get the group process ids of all agitator processes


### PR DESCRIPTION
This PR addresses a possible race condition that was identified below:

> 
> @DomGarguilo I noticed a quirk while testing that I think could be a follow on task. For the stop agitator, I made the `pkill` kill the sleep first and then anything matching `agitator`. This works but I noticed that the script may run before being killed and introduces a race condition. Here is the log from the tserver agitator:
> <pre>
> 20220112 12:37:19 Starting tserver agitation. Kill every 20 minutes, restart every 10 minutes.
> 20220112 12:37:19 Will randomly kill between 1 and 1 of the following: localhost
> 20220112 12:37:19 Sleeping for 20 minutes
> Terminated
> 20220112 12:49:54 Killing tserver at localhost
> </pre>
> 
> There should be a way to kill the agitator process and all its child processes (i.e. the sleep function) with one command.

_Originally posted by @milleruntime in https://github.com/apache/accumulo-testing/issues/184#issuecomment-1011324701_