### PR TITLE
Update usages of ThreadPools.createFixedThreadPool

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
@@ -222,7 +222,7 @@ public class Module extends Node {
       fixture.setUp(state, env);
     }
 
-    ExecutorService service = ThreadPools.createFixedThreadPool(1, "RandomWalk Runner");
+    ExecutorService service = ThreadPools.createFixedThreadPool(1, "RandomWalk Runner", false);
 
     try {
       Node initNode = getNode(initNodeId);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
@@ -60,7 +60,8 @@ public class Setup extends Test {
     state.set("fs", FileSystem.get(env.getHadoopConfiguration()));
     state.set("bulkImportSuccess", "true");
     BulkPlusOne.counter.set(0l);
-    ThreadPoolExecutor e = ThreadPools.createFixedThreadPool(MAX_POOL_SIZE, "bulkImportPool");
+    ThreadPoolExecutor e = ThreadPools.createFixedThreadPool(MAX_POOL_SIZE, "bulkImportPool",
+        false);
     state.set("pool", e);
   }
 


### PR DESCRIPTION
https://github.com/apache/accumulo/pull/2432 introduced a new parameter into `ThreadPools.createFixedThreadPool()`. This PR adds the new parameter to fix the build errors.

The new parameter has been set to false since we most likely wont be looking at any metrics for thread pools created inside the test code.