### PR TITLE
Upgrade versioning in performance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ run in Docker:
 
     * `conf/accumulo-client.properties` - Configure this file from your Accumulo install
     * `conf/accumulo-testing.properties` - Configure this file for testing
-    * `target/accumulo-testing-2.0.0-SNAPSHOT-shaded.jar` - Can be created using `./bin/build`
+    * `target/accumulo-testing-2.1.0-SNAPSHOT-shaded.jar` - Can be created using `./bin/build`
 
    Run the following command to create the image. `HADOOP_HOME` should be where Hadoop is installed on your cluster.
    `HADOOP_USER_NAME` should match the user running Hadoop on your cluster.

--- a/bin/performance
+++ b/bin/performance
@@ -21,7 +21,7 @@
 
 bin_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 at_home=$( cd "$( dirname "$bin_dir" )" && pwd )
-at_version=2.0.0-SNAPSHOT
+at_version=2.1.0-SNAPSHOT
 
 function print_usage() {
   cat <<EOF


### PR DESCRIPTION
Versioning of accumulo-testing was changed to 2.1.0. This changes the Readme and the performance script (which looked for the accumulo-testing jar) to match that versioning. 