### PR TITLE
runs mvn install for accumulo in terraform

### DIFF
--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -76,7 +76,7 @@ else
   git clone ${accumulo_repo} accumulo-repo
   cd accumulo-repo
   git checkout ${accumulo_branch_name}
-  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean package -DskipTests -DskipITs
+  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean install -PskipQA
   mkdir -p ${software_root}/accumulo
   tar zxf assemble/target/accumulo-${accumulo_version}-bin.tar.gz -C ${software_root}/accumulo
 fi


### PR DESCRIPTION
Run mvn install when building accumulo so that the accumulo-testing will pick up the correct accumulo snapshot jars.