### PR TITLE
Hide unit modules from list in rwalk usage printout

### DIFF
--- a/bin/rwalk
+++ b/bin/rwalk
@@ -28,7 +28,7 @@ Usage: $0 <module> (<argument>)
    Modules listed below located in <at_home>/src/main/resources/randomwalk/modules
 
 EOF
-  find "$at_home/src/main/resources/randomwalk/modules/." -name "*.xml" -printf "%f\n"
+  find "$at_home/src/main/resources/randomwalk/modules/." -maxdepth 1 -name "*.xml" -printf "%f\n"
 }
 
 export CLASSPATH="$TEST_JAR_PATH:$HADOOP_API_JAR:$HADOOP_RUNTIME_JAR:$CLASSPATH"


### PR DESCRIPTION
Fixes #213 

The changes in this PR will make is to that the two xml files that are in the `unit/` sub-directory will not be printed by limiting the depth of the search of the find command.

run `./bin/rwalk` to verify that `Basic.xml` and `Simple.xml` are not present in the list of modules.