### PR TITLE
Make use of Random object from TestEnv

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/gcs/Generator.java
+++ b/src/main/java/org/apache/accumulo/testing/gcs/Generator.java
@@ -38,7 +38,7 @@ public class Generator {
   // The max number of work chains that should be active at any one time.
   private final int maxActiveWork;
 
-  Random rand = new Random();
+  Random rand;
 
   private final Persistence persistence;
 
@@ -48,6 +48,8 @@ public class Generator {
 
     this.maxWork = gcsEnv.getMaxWork();
     this.maxActiveWork = gcsEnv.getMaxActiveWork();
+
+    this.rand = gcsEnv.getRandom();
   }
 
   private void run() {

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.testing.randomwalk.bulk;
 
 import java.net.InetAddress;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -56,7 +55,7 @@ public class Setup extends Test {
     } catch (TableExistsException ex) {
       // expected if there are multiple walkers
     }
-    state.setRandom(new Random());
+    state.setRandom(env.getRandom());
     state.set("fs", FileSystem.get(env.getHadoopConfiguration()));
     state.set("bulkImportSuccess", "true");
     BulkPlusOne.counter.set(0l);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Setup.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.testing.randomwalk.concurrent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.testing.randomwalk.RandWalkEnv;
 import org.apache.accumulo.testing.randomwalk.State;
@@ -29,7 +28,7 @@ public class Setup extends Test {
 
   @Override
   public void visit(State state, RandWalkEnv env, Properties props) throws Exception {
-    state.setRandom(new Random());
+    state.setRandom(env.getRandom());
 
     int numTables = Integer.parseInt(props.getProperty("numTables", "9"));
     int numNamespaces = Integer.parseInt(props.getProperty("numNamespaces", "2"));

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/conditional/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/conditional/Setup.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.testing.randomwalk.conditional;
 
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriterConfig;
@@ -31,8 +30,7 @@ public class Setup extends Test {
 
   @Override
   public void visit(State state, RandWalkEnv env, Properties props) throws Exception {
-    Random rand = new Random();
-    state.setRandom(rand);
+    state.setRandom(env.getRandom());
 
     int numBanks = Integer.parseInt(props.getProperty("numBanks", "1000"));
     log.debug("numBanks = " + numBanks);
@@ -48,7 +46,7 @@ public class Setup extends Test {
     try {
       env.getAccumuloClient().tableOperations().create(tableName);
       log.debug("created table " + tableName);
-      boolean blockCache = rand.nextBoolean();
+      boolean blockCache = env.getRandom().nextBoolean();
       env.getAccumuloClient().tableOperations().setProperty(tableName,
           Property.TABLE_BLOCKCACHE_ENABLED.getKey(), blockCache + "");
       log.debug("set " + Property.TABLE_BLOCKCACHE_ENABLED.getKey() + " " + blockCache);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/image/ImageFixture.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/image/ImageFixture.java
@@ -20,7 +20,6 @@ import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -78,8 +77,7 @@ public class ImageFixture extends Fixture {
       throw e;
     }
 
-    Random rand = new Random();
-    if (rand.nextInt(10) < 5) {
+    if (env.getRandom().nextInt(10) < 5) {
       // setup locality groups
       Map<String,Set<Text>> groups = getLocalityGroups();
 

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/image/ScanMeta.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/image/ScanMeta.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -61,8 +60,7 @@ public class ScanMeta extends Test {
     int minScan = Integer.parseInt(props.getProperty("minScan"));
     int maxScan = Integer.parseInt(props.getProperty("maxScan"));
 
-    Random rand = new Random();
-    int numToScan = rand.nextInt(maxScan - minScan) + minScan;
+    int numToScan = env.getRandom().nextInt(maxScan - minScan) + minScan;
 
     Map<Text,Text> hashes = new HashMap<>();
 

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/image/TableOp.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/image/TableOp.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.testing.randomwalk.image;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -35,9 +34,8 @@ public class TableOp extends Test {
   public void visit(State state, RandWalkEnv env, Properties props) throws Exception {
 
     // choose a table
-    Random rand = new Random();
     String tableName;
-    if (rand.nextInt(10) < 8) {
+    if (env.getRandom().nextInt(10) < 8) {
       tableName = state.getString("imageTableName");
     } else {
       tableName = state.getString("indexTableName");
@@ -52,7 +50,7 @@ public class TableOp extends Test {
     }
 
     // choose a random action
-    int num = rand.nextInt(10);
+    int num = env.getRandom().nextInt(10);
     if (num > 6) {
       log.debug("Retrieving info for " + tableName);
       tableOps.getLocalityGroups(tableName);
@@ -64,7 +62,7 @@ public class TableOp extends Test {
       tableOps.clearLocatorCache(tableName);
     }
 
-    if (rand.nextInt(10) < 3) {
+    if (env.getRandom().nextInt(10) < 3) {
       Map<String,Set<Text>> groups = tableOps.getLocalityGroups(state.getString("imageTableName"));
 
       if (groups.size() == 0) {

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/image/Verify.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/image/Verify.java
@@ -22,7 +22,6 @@ import java.security.MessageDigest;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -44,10 +43,8 @@ public class Verify extends Test {
   @Override
   public void visit(State state, RandWalkEnv env, Properties props) throws Exception {
 
-    Random rand = new Random();
-
     int maxVerify = Integer.parseInt(props.getProperty("maxVerify"));
-    int numVerifications = rand.nextInt(maxVerify - 1) + 1;
+    int numVerifications = env.getRandom().nextInt(maxVerify - 1) + 1;
 
     indexTableName = state.getString("indexTableName");
     imageTableName = state.getString("imageTableName");

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/image/Write.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/image/Write.java
@@ -20,7 +20,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.security.MessageDigest;
 import java.util.Properties;
-import java.util.Random;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.BatchWriter;
@@ -56,10 +55,9 @@ public class Write extends Test {
     int maxSize = Integer.parseInt(props.getProperty("maxSize"));
     int minSize = Integer.parseInt(props.getProperty("minSize"));
 
-    Random rand = new Random();
-    int numBytes = rand.nextInt(maxSize - minSize) + minSize;
+    int numBytes = env.getRandom().nextInt(maxSize - minSize) + minSize;
     byte[] imageBytes = new byte[numBytes];
-    rand.nextBytes(imageBytes);
+    env.getRandom().nextBytes(imageBytes);
     m.put(CONTENT_COLUMN_FAMILY, IMAGE_COLUMN_QUALIFIER, new Value(imageBytes));
 
     // store size

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/BulkImport.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/BulkImport.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.testing.randomwalk.multitable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -66,16 +65,15 @@ public class BulkImport extends Test {
       return;
     }
 
-    Random rand = new Random();
-    String tableName = tables.get(rand.nextInt(tables.size()));
+    String tableName = tables.get(env.getRandom().nextInt(tables.size()));
 
     String uuid = UUID.randomUUID().toString();
     final Path dir = new Path("/tmp/bulk", uuid);
     final Path fail = new Path(dir.toString() + "_fail");
     final FileSystem fs = (FileSystem) state.get("fs");
     fs.mkdirs(fail);
-    final int parts = rand.nextInt(10) + 1;
-    final boolean useLegacyBulk = rand.nextBoolean();
+    final int parts = env.getRandom().nextInt(10) + 1;
+    final boolean useLegacyBulk = env.getRandom().nextBoolean();
 
     TreeSet<String> rows = new TreeSet<>();
     for (int i = 0; i < ROWS; i++)

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/CopyTable.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/CopyTable.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.testing.randomwalk.multitable;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
@@ -47,8 +46,7 @@ public class CopyTable extends Test {
     if (tables.isEmpty())
       return;
 
-    Random rand = new Random();
-    String srcTableName = tables.remove(rand.nextInt(tables.size()));
+    String srcTableName = tables.remove(env.getRandom().nextInt(tables.size()));
 
     int nextId = ((Integer) state.get("nextId")).intValue();
     String dstTableName = String.format("%s_%d", state.getString("tableNamePrefix"), nextId);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/DropTable.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/DropTable.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.testing.randomwalk.multitable;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.testing.randomwalk.RandWalkEnv;
@@ -38,8 +37,7 @@ public class DropTable extends Test {
       return;
     }
 
-    Random rand = new Random();
-    String tableName = tables.remove(rand.nextInt(tables.size()));
+    String tableName = tables.remove(env.getRandom().nextInt(tables.size()));
 
     try {
       env.getAccumuloClient().tableOperations().delete(tableName);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/OfflineTable.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/OfflineTable.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.testing.randomwalk.multitable;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.testing.randomwalk.RandWalkEnv;
 import org.apache.accumulo.testing.randomwalk.State;
@@ -36,12 +35,11 @@ public class OfflineTable extends Test {
       return;
     }
 
-    Random rand = new Random();
-    String tableName = tables.get(rand.nextInt(tables.size()));
+    String tableName = tables.get(env.getRandom().nextInt(tables.size()));
 
-    env.getAccumuloClient().tableOperations().offline(tableName, rand.nextBoolean());
+    env.getAccumuloClient().tableOperations().offline(tableName, env.getRandom().nextBoolean());
     log.debug("Table " + tableName + " offline ");
-    env.getAccumuloClient().tableOperations().online(tableName, rand.nextBoolean());
+    env.getAccumuloClient().tableOperations().online(tableName, env.getRandom().nextBoolean());
     log.debug("Table " + tableName + " online ");
   }
 }

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/Write.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/multitable/Write.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.security.MessageDigest;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.BatchWriter;
@@ -49,8 +48,7 @@ public class Write extends Test {
       return;
     }
 
-    Random rand = new Random();
-    String tableName = tables.get(rand.nextInt(tables.size()));
+    String tableName = tables.get(env.getRandom().nextInt(tables.size()));
 
     BatchWriter bw = null;
     try {
@@ -70,9 +68,9 @@ public class Write extends Test {
     Mutation m = new Mutation(new Text(uuid));
 
     // create a fake payload between 4KB and 16KB
-    int numBytes = rand.nextInt(12000) + 4000;
+    int numBytes = env.getRandom().nextInt(12000) + 4000;
     byte[] payloadBytes = new byte[numBytes];
-    rand.nextBytes(payloadBytes);
+    env.getRandom().nextBytes(payloadBytes);
     m.put(meta, new Text("payload"), new Value(payloadBytes));
 
     // store size

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/AlterSystemPerm.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/AlterSystemPerm.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.testing.randomwalk.security;
 
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -41,8 +40,7 @@ public class AlterSystemPerm extends Test {
 
     SystemPermission sysPerm;
     if (perm.equals("random")) {
-      Random r = new Random();
-      int i = r.nextInt(SystemPermission.values().length);
+      int i = env.getRandom().nextInt(SystemPermission.values().length);
       sysPerm = SystemPermission.values()[i];
     } else
       sysPerm = SystemPermission.valueOf(perm);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/AlterTablePerm.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/AlterTablePerm.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.testing.randomwalk.security;
 
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -56,8 +55,7 @@ public class AlterTablePerm extends Test {
 
     TablePermission tabPerm;
     if (perm.equals("random")) {
-      Random r = new Random();
-      int i = r.nextInt(TablePermission.values().length);
+      int i = env.getRandom().nextInt(TablePermission.values().length);
       tabPerm = TablePermission.values()[i];
     } else
       tabPerm = TablePermission.valueOf(perm);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/ChangePass.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/ChangePass.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.testing.randomwalk.security;
 
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -59,11 +58,9 @@ public class ChangePass extends Test {
       hasPerm = client.securityOperations().hasSystemPermission(principal,
           SystemPermission.ALTER_USER) || principal.equals(target);
 
-      Random r = new Random();
-
-      byte[] newPassw = new byte[r.nextInt(50) + 1];
+      byte[] newPassw = new byte[env.getRandom().nextInt(50) + 1];
       for (int i = 0; i < newPassw.length; i++)
-        newPassw[i] = (byte) ((r.nextInt(26) + 65) & 0xFF);
+        newPassw[i] = (byte) ((env.getRandom().nextInt(26) + 65) & 0xFF);
 
       PasswordToken newPass = new PasswordToken(newPassw);
       try {

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/SetAuths.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/SetAuths.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.testing.randomwalk.security;
 
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -58,12 +57,11 @@ public class SetAuths extends Test {
       if (authsString.equals("_random")) {
         String[] possibleAuths = WalkingSecurity.get(state, env).getAuthsArray();
 
-        Random r = new Random();
-        int i = r.nextInt(possibleAuths.length);
+        int i = env.getRandom().nextInt(possibleAuths.length);
         String[] authSet = new String[i];
         int length = possibleAuths.length;
         for (int j = 0; j < i; j++) {
-          int nextRand = r.nextInt(length);
+          int nextRand = env.getRandom().nextInt(length);
           authSet[j] = possibleAuths[nextRand];
           length--;
           possibleAuths[nextRand] = possibleAuths[length];

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/TableOp.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/TableOp.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -65,8 +64,7 @@ public class TableOp extends Test {
       String action = props.getProperty("action", "_random");
       TablePermission tp;
       if ("_random".equalsIgnoreCase(action)) {
-        Random r = new Random();
-        tp = TablePermission.values()[r.nextInt(TablePermission.values().length)];
+        tp = TablePermission.values()[env.getRandom().nextInt(TablePermission.values().length)];
       } else {
         tp = TablePermission.valueOf(action);
       }

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/sequential/BatchVerify.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/sequential/BatchVerify.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -40,11 +39,9 @@ public class BatchVerify extends Test {
   @Override
   public void visit(State state, RandWalkEnv env, Properties props) throws Exception {
 
-    Random rand = new Random();
-
     long numWrites = state.getLong("numWrites");
     int maxVerify = Integer.parseInt(props.getProperty("maxVerify", "2000"));
-    long numVerify = rand.nextInt(maxVerify - 1) + 1;
+    long numVerify = env.getRandom().nextInt(maxVerify - 1) + 1;
 
     if (numVerify > (numWrites / 4)) {
       numVerify = numWrites / 4;
@@ -57,7 +54,7 @@ public class BatchVerify extends Test {
       int count = 0;
       List<Range> ranges = new ArrayList<>();
       while (count < numVerify) {
-        long rangeStart = rand.nextInt((int) numWrites);
+        long rangeStart = env.getRandom().nextInt((int) numWrites);
         long rangeEnd = rangeStart + 99;
         if (rangeEnd > (numWrites - 1)) {
           rangeEnd = numWrites - 1;

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/shard/ShardFixture.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/shard/ShardFixture.java
@@ -80,28 +80,26 @@ public class ShardFixture extends Fixture {
     String hostname = InetAddress.getLocalHost().getHostName().replaceAll("[-.]", "_");
     String pid = env.getPid();
 
-    Random rand = new Random();
-
-    int numPartitions = rand.nextInt(90) + 10;
+    int numPartitions = env.getRandom().nextInt(90) + 10;
 
     state.set("indexTableName",
         String.format("ST_index_%s_%s_%d", hostname, pid, System.currentTimeMillis()));
     state.set("docTableName",
         String.format("ST_docs_%s_%s_%d", hostname, pid, System.currentTimeMillis()));
     state.set("numPartitions", Integer.valueOf(numPartitions));
-    state.set("cacheIndex", rand.nextDouble() < .5);
-    state.set("rand", rand);
+    state.set("cacheIndex", env.getRandom().nextDouble() < .5);
+    state.set("rand", env.getRandom());
     state.set("nextDocID", Long.valueOf(0));
 
     AccumuloClient client = env.getAccumuloClient();
 
-    createIndexTable(this.log, state, env, "", rand);
+    createIndexTable(this.log, state, env, "", env.getRandom());
 
     String docTableName = state.getString("docTableName");
     NewTableConfiguration ntc = new NewTableConfiguration();
-    SortedSet<Text> splits = genSplits(0xff, rand.nextInt(32) + 1, "%02x");
+    SortedSet<Text> splits = genSplits(0xff, env.getRandom().nextInt(32) + 1, "%02x");
     ntc.withSplits(splits);
-    if (rand.nextDouble() < .5) {
+    if (env.getRandom().nextDouble() < .5) {
       ntc.setProperties(Map.of(Property.TABLE_BLOOM_ENABLED.getKey(), "true"));
       log.info("Enabling bloom filters for table {}", docTableName);
     }


### PR DESCRIPTION
Instead of creating new `Random` Objects, we should use the object that is already available within `TestEnv`.

This PR replaces the usages where new `Random` objects are created, where possible.