### PR TITLE
Add per table crypto settings to Terraform configuration

### DIFF
--- a/contrib/terraform-testing-infrastructure/modules/cloud-init-config/templates/cloud-init.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/cloud-init-config/templates/cloud-init.tftpl
@@ -67,6 +67,7 @@ packages:
   - pssh
   - make
 %{ endif ~}
+  - openssl
   - docker-ce
   - docker-ce-cli
   - containerd.io

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/accumulo-properties.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/accumulo-properties.tftpl
@@ -19,7 +19,13 @@ compactor.port.search=true
 # OpenTelemetry settings
 general.opentelemetry.enabled=true
 
-#Micrometer settings
+# Micrometer settings
 general.micrometer.enabled=true
 general.micrometer.jvm.metrics.enabled=true
 general.micrometer.factory=org.apache.accumulo.test.metrics.TestStatsDRegistryFactory
+
+# Per-Table Encryption
+instance.crypto.opts.factory=org.apache.accumulo.core.spi.crypto.PerTableCryptoServiceFactory
+general.custom.crypto.recovery.service=org.apache.accumulo.core.spi.crypto.AESCryptoService
+general.custom.crypto.wal.service=org.apache.accumulo.core.spi.crypto.AESCryptoService
+general.custom.crypto.key.uri=file://${software_root}/accumulo/accumulo-${accumulo_version}/conf/per-table-enc-key

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -83,6 +83,12 @@ fi
 ${software_root}/accumulo/accumulo-${accumulo_version}/bin/accumulo-util build-native
 
 #
+# Generate a 32-byte encryption key and put into ${software_root}/accumulo/accumulo-${accumulo_version}/conf.
+# This will get distributed to all nodes and the properties that use the file are in accumulo.properties
+#
+openssl rand -out ${software_root}/accumulo/accumulo-${accumulo_version}/conf/per-table-enc-key
+
+#
 # OpenTelemetry dependencies
 #
 if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.17.0.jar ]; then

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -86,7 +86,7 @@ ${software_root}/accumulo/accumulo-${accumulo_version}/bin/accumulo-util build-n
 # Generate a 32-byte encryption key and put into ${software_root}/accumulo/accumulo-${accumulo_version}/conf.
 # This will get distributed to all nodes and the properties that use the file are in accumulo.properties
 #
-openssl rand -out ${software_root}/accumulo/accumulo-${accumulo_version}/conf/per-table-enc-key
+openssl rand -out ${software_root}/accumulo/accumulo-${accumulo_version}/conf/per-table-enc-key 32
 
 #
 # OpenTelemetry dependencies


### PR DESCRIPTION
Update Terraform configuration to include per-table crypto feature added in Accumulo 2.1.0 using instructions from https://github.com/apache/accumulo-website/pull/342.