### PR TITLE
fixes two bulk import RW bugs

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/BulkPlusOne.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/BulkPlusOne.java
@@ -59,8 +59,8 @@ public class BulkPlusOne extends BulkImportTest {
     log.debug("Bulk loading from {}", dir);
     final int parts = env.getRandom().nextInt(10) + 1;
 
-    TreeSet<Integer> startRows = Stream.generate(() -> env.getRandom().nextInt(LOTS)).limit(parts)
-        .collect(Collectors.toCollection(TreeSet::new));
+    TreeSet<Integer> startRows = Stream.generate(() -> env.getRandom().nextInt(LOTS))
+        .limit(parts - 1).collect(Collectors.toCollection(TreeSet::new));
     startRows.add(0);
 
     List<String> printRows = startRows.stream().map(row -> String.format(FMT, row))

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Verify.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Verify.java
@@ -77,33 +77,33 @@ public class Verify extends Test {
       scanner.clearColumns();
       scanner.fetchColumnFamily(BulkPlusOne.MARKER_CF);
       rowIter = new RowIterator(scanner);
-    }
 
-    while (rowIter.hasNext()) {
-      Iterator<Entry<Key,Value>> row = rowIter.next();
-      long prev = 0;
-      Text rowText = null;
-      while (row.hasNext()) {
-        Entry<Key,Value> entry = row.next();
+      while (rowIter.hasNext()) {
+        Iterator<Entry<Key,Value>> row = rowIter.next();
+        long prev = 0;
+        Text rowText = null;
+        while (row.hasNext()) {
+          Entry<Key,Value> entry = row.next();
 
-        if (rowText == null)
-          rowText = entry.getKey().getRow();
+          if (rowText == null)
+            rowText = entry.getKey().getRow();
 
-        long curr = Long.parseLong(entry.getKey().getColumnQualifier().toString());
+          long curr = Long.parseLong(entry.getKey().getColumnQualifier().toString());
 
-        if (curr - 1 != prev)
-          throw new Exception(
-              "Bad marker count " + entry.getKey() + " " + entry.getValue() + " " + prev);
+          if (curr - 1 != prev)
+            throw new Exception(
+                "Bad marker count " + entry.getKey() + " " + entry.getValue() + " " + prev);
 
-        if (!entry.getValue().toString().equals("1"))
-          throw new Exception("Bad marker value " + entry.getKey() + " " + entry.getValue());
+          if (!entry.getValue().toString().equals("1"))
+            throw new Exception("Bad marker value " + entry.getKey() + " " + entry.getValue());
 
-        prev = curr;
-      }
+          prev = curr;
+        }
 
-      if (BulkPlusOne.counter.get() != prev) {
-        throw new Exception("Row " + rowText + " does not have all markers "
-            + BulkPlusOne.counter.get() + " " + prev);
+        if (BulkPlusOne.counter.get() != prev) {
+          throw new Exception("Row " + rowText + " does not have all markers "
+              + BulkPlusOne.counter.get() + " " + prev);
+        }
       }
     }
 


### PR DESCRIPTION
One bug is an off by one bug introduced when changing code from a loop to a stream. After that change the set was one larger than it used to be.  This caused the test to generate less data than intended for each import which inevitably caused the counts to be non-zero. 

The other bug is using a scanner outside of a try with resources block that closes the scanner.