### PR TITLE
Fix file name and license formatting in merkle-replication README file

### DIFF
--- a/test/merkle-replication/README.md
+++ b/test/merkle-replication/README.md
@@ -6,7 +6,7 @@ The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
 the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
I found this by looking in the rat.txt file which incorrectly labeled this file as a Notice file probably because its filename was missing the file extension `.md`. Because of this, the file was being incorrectly displayed which can be seen by viewing this file online in github:

https://github.com/apache/accumulo-testing/tree/main/test/merkle-replication