### PR TITLE
Enable reloading log4j2 config

### DIFF
--- a/conf/log4j2.properties
+++ b/conf/log4j2.properties
@@ -20,6 +20,7 @@
 name = AccumuloTestingDefaultLoggingProperties
 status = info
 dest = err
+monitorInterval = 30
 
 appenders = console
 appender.console.type = Console


### PR DESCRIPTION
While running random walk test one of the walkers got stuck.  I tried to change the accumulo testing log4j2 config to enable accumulo client debugging but nothing happened.  Looking into it I think an additional setting is needed in the log4j config for this to work.