### PR TITLE
Update pom to use accumulo 3.0.0-SNAPSHOT instead of 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <name>Apache Accumulo Testing</name>
   <description>Testing tools for Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.1.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>3.0.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>${project.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/shard/SortTool.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/shard/SortTool.java
@@ -45,7 +45,6 @@ public class SortTool extends Configured implements Tool {
     this.splits = splits;
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   public int run(String[] args) throws Exception {
     Job job = Job.getInstance(getConf(), this.getClass().getSimpleName());

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/shard/SortTool.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/shard/SortTool.java
@@ -60,18 +60,16 @@ public class SortTool extends Configured implements Tool {
     SequenceFileInputFormat.setInputPaths(job, seqFile);
 
     job.setPartitionerClass(
-        org.apache.accumulo.core.client.mapreduce.lib.partition.KeyRangePartitioner.class);
-    org.apache.accumulo.core.client.mapreduce.lib.partition.KeyRangePartitioner.setSplitFile(job,
-        splitFile);
+        org.apache.accumulo.hadoop.mapreduce.partition.KeyRangePartitioner.class);
+    org.apache.accumulo.hadoop.mapreduce.partition.KeyRangePartitioner.setSplitFile(job, splitFile);
 
     job.setMapOutputKeyClass(Key.class);
     job.setMapOutputValueClass(Value.class);
 
     job.setNumReduceTasks(splits.size() + 1);
 
-    job.setOutputFormatClass(
-        org.apache.accumulo.core.client.mapreduce.AccumuloFileOutputFormat.class);
-    org.apache.accumulo.core.client.mapreduce.AccumuloFileOutputFormat.setOutputPath(job,
+    job.setOutputFormatClass(org.apache.accumulo.hadoop.mapreduce.AccumuloFileOutputFormat.class);
+    org.apache.accumulo.hadoop.mapreduce.AccumuloFileOutputFormat.setOutputPath(job,
         new Path(outputDir));
 
     job.waitForCompletion(true);


### PR DESCRIPTION
This also fixes `ShardTool` which broke due to this change. This should fix the test failures seen in accumulo-testing. I am unsure on if we plan to keep `ShardTool` since it was still using a deprecated class that 3.0.0 aims to remove. 