### PR TITLE
fixes build issue by supplying Accumulo version

### DIFF
--- a/conf/env.sh
+++ b/conf/env.sh
@@ -82,7 +82,7 @@ fi
 export HADOOP_API_JAR="${at_home}"/target/dependency/hadoop-client-api.jar
 export HADOOP_RUNTIME_JAR="${at_home}"/target/dependency/hadoop-client-runtime.jar
 if [[ ! -f $HADOOP_API_JAR || ! -f $HADOOP_RUNTIME_JAR ]]; then
-  mvn dependency:copy-dependencies -Dmdep.stripVersion=true -DincludeArtifactIds=hadoop-client-api,hadoop-client-runtime -Dhadoop.version="$HADOOP_VERSION"
+  mvn dependency:copy-dependencies -Dmdep.stripVersion=true -DincludeArtifactIds=hadoop-client-api,hadoop-client-runtime -Dhadoop.version="$HADOOP_VERSION" -D accumulo.version="$ACCUMULO_VERSION"
 fi
 
 # Agitator


### PR DESCRIPTION
Tried to run bin/build against accumulo 2.1.1-SNAPSHOT and it failed looking for 2.1.0-SNAPSHOT resources.  This was because script was not passing the runtime Accumulo version.  Modified the script to pass the runtime version.