### PR TITLE
Remove log4j-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,10 +93,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
The log4j version was updated in https://github.com/apache/accumulo/pull/3215 which fixes a bug that required log4j-core to be install. With the new version now being tracked in accumulo-testing, this import is no longer needed.