### PR TITLE
Updates to Terraform configuration based on recent changes

### DIFF
--- a/contrib/terraform-testing-infrastructure/README.md
+++ b/contrib/terraform-testing-infrastructure/README.md
@@ -330,11 +330,11 @@ This Terraform configuration:
      and builds the software using Maven, then untars the binary tarball to
      `${software_root}/accumulo/accumulo-${accumulo_version}`
   5. Downloads the [OpenTelemetry](https://opentelemetry.io/) Java Agent jar file and copies it to
-     `${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.19.0.jar`
+     `${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.32.0.jar`
   6. Copies the Accumulo `test` jar to `${software_root}/accumulo/accumulo-${accumulo_version}/lib`
      so that `org.apache.accumulo.test.metrics.TestStatsDRegistryFactory` is on the classpath
   7. Downloads the [Micrometer](https://micrometer.io/) StatsD Registry jar file and copies it to
-     `${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.9.5.jar`
+     `${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.12.1.jar`
   8. Clones, if necessary, the Apache Accumulo Testing Git repo from `${accumulo_testing_repo}`
      into `${software_root}/sources/accumulo-testing-repo`. It switches to the
      `${accumulo_testing_branch_name}` branch and builds the software using Maven.

--- a/contrib/terraform-testing-infrastructure/aws/main.tf
+++ b/contrib/terraform-testing-infrastructure/aws/main.tf
@@ -134,6 +134,8 @@ module "cloud_init_config" {
   accumulo_version     = var.accumulo_version
   authorized_ssh_keys  = local.ssh_keys[*]
   cluster_type         = "aws"
+  os_distro            = var.os_distro
+  os_version           = var.os_version
 
   optional_cloudinit_config = var.optional_cloudinit_config
   cloudinit_merge_type      = var.cloudinit_merge_type
@@ -229,6 +231,7 @@ locals {
 module "config_files" {
   source = "../modules/config-files"
 
+  os_distro     = var.os_distro
   software_root = var.software_root
   upload_host   = var.private_network ? local.manager_private_ip : local.manager_ip
   manager_ip    = local.manager_private_ip

--- a/contrib/terraform-testing-infrastructure/aws/variables.tf
+++ b/contrib/terraform-testing-infrastructure/aws/variables.tf
@@ -197,3 +197,17 @@ variable "cloudinit_merge_type" {
   description = "Describes the merge behavior for overlapping config blocks in cloud-init."
   nullable    = true
 }
+
+variable "os_distro" {
+  description = "The distribution name of the operating system used by the AMI. Expected values: centos, rhel, or ubuntu"
+  nullable    = false
+  validation {
+    condition     = contains(["centos", "rhel", "ubuntu"], var.os_distro)
+    error_message = "The value of os_distro must be either 'centos', 'rhel', or 'ubuntu'."
+  }
+}
+
+variable "os_version" {
+  description = "The version of the operating system used by the AMI"
+  nullable    = false
+}

--- a/contrib/terraform-testing-infrastructure/azure/main.tf
+++ b/contrib/terraform-testing-infrastructure/azure/main.tf
@@ -67,7 +67,6 @@ provider "azurerm" {
 }
 
 locals {
-  os_type = can(regex("^.*[Uu]buntu.*$", var.vm_image.offer)) ? "ubuntu" : "centos"
 
   ssh_keys = toset(concat(var.authorized_ssh_keys, [for k in var.authorized_ssh_key_files : file(k)]))
 
@@ -168,7 +167,9 @@ module "cloud_init_config" {
   accumulo_branch_name = var.accumulo_branch_name
   accumulo_version     = var.accumulo_version
   authorized_ssh_keys  = local.ssh_keys[*]
-  os_type              = local.os_type
+  os_distro            = var.os_distro
+  os_version           = var.os_version
+
   cluster_type         = "azure"
 
   optional_cloudinit_config = var.optional_cloudinit_config
@@ -418,8 +419,7 @@ resource "null_resource" "wait_for_workers_cloud_init" {
 module "config_files" {
   source = "../modules/config-files"
 
-  os_type = local.os_type
-
+  os_distro     = var.os_distro
   software_root = var.software_root
   upload_host   = local.manager_ip
   manager_ip    = local.manager_private_ip

--- a/contrib/terraform-testing-infrastructure/azure/variables.tf
+++ b/contrib/terraform-testing-infrastructure/azure/variables.tf
@@ -275,3 +275,18 @@ variable "cloudinit_merge_type" {
   description = "Describes the merge behavior for overlapping config blocks in cloud-init."
   nullable    = true
 }
+
+variable "os_distro" {
+  description = "The distribution name of the operating system used by the AMI. Expected values: centos, rhel, or ubuntu"
+  nullable    = false
+  validation {
+    condition     = contains(["centos", "rhel", "ubuntu"], var.os_distro)
+    error_message = "The value of os_distro must be either 'centos', 'rhel', or 'ubuntu'."
+  }
+}
+
+variable "os_version" {
+  description = "The version of the operating system used by the AMI"
+  nullable    = false
+}
+

--- a/contrib/terraform-testing-infrastructure/modules/cloud-init-config/files/update-hosts-genders.sh
+++ b/contrib/terraform-testing-infrastructure/modules/cloud-init-config/files/update-hosts-genders.sh
@@ -42,7 +42,7 @@ $begin_hosts_marker
 $(<"$HOSTS_ADDITIONS")
 $end_hosts_marker
 EOF
-# Strip out any previously applied hosts additiona, and then tack the new ones on to the end of /etc/hosts.
+# Strip out any previously applied hosts additions, and then tack the new ones on to the end of /etc/hosts.
 sudo sed -ri '/^'"$begin_hosts_marker"'$/,/^'"$end_hosts_marker"'$/d' /etc/hosts
 cat "$TMPHOSTS" | sudo tee -a /etc/hosts >/dev/null
 
@@ -55,6 +55,7 @@ $end_genders_marker
 EOF
 [[ -f /etc/genders ]] && sudo sed -ri '/^'"$begin_genders_marker"'$/,/^'"$end_genders_marker"'$/d' /etc/genders
 cat "$TMPGENDERS" | sudo tee -a /etc/genders >/dev/null
+sudo chmod 644 /etc/genders
 echo "Check genders file validity..."
 nodeattr -k
 

--- a/contrib/terraform-testing-infrastructure/modules/cloud-init-config/main.tf
+++ b/contrib/terraform-testing-infrastructure/modules/cloud-init-config/main.tf
@@ -27,6 +27,8 @@ variable "hadoop_version" {}
 variable "accumulo_branch_name" {}
 variable "accumulo_version" {}
 variable "authorized_ssh_keys" {}
+variable "os_distro" {}
+variable "os_version" {}
 variable "lvm_mount_point" {
   default = null
   description = "Mount point for the LVM volume containing managed disks. If not specified, then no LVM volume is created."
@@ -44,15 +46,6 @@ variable "cloudinit_merge_type" {
 variable "optional_cloudinit_config" {
   default  = ""
   nullable = false
-}
-variable "os_type" {
-  default  = "centos"
-  type     = string
-  nullable = false
-  validation {
-    condition     = contains(["centos", "ubuntu"], var.os_type)
-    error_message = "The value of os_type must be either 'centos' or 'ubuntu'."
-  }
 }
 variable "cluster_type" {
   type     = string
@@ -90,7 +83,9 @@ locals {
     authorized_ssh_keys  = local.ssh_keys[*]
     lvm_mount_point      = var.lvm_mount_point != null ? var.lvm_mount_point : ""
     lvm_disk_count       = var.lvm_disk_count != null ? var.lvm_disk_count : ""
-    os_type              = var.os_type
+    os_distro            = var.os_distro
+    os_version           = var.os_version
+    centos7              = substr(var.os_version, 0, 1) == "7" ? "true" : "false"
     cluster_type         = var.cluster_type
     hadoop_public_key    = indent(6, tls_private_key.hadoop.public_key_openssh)
     hadoop_private_key   = indent(6, tls_private_key.hadoop.private_key_pem)

--- a/contrib/terraform-testing-infrastructure/modules/cloud-init-config/templates/cloud-init.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/cloud-init-config/templates/cloud-init.tftpl
@@ -31,7 +31,7 @@ users:
       - ${key}
 %{ endfor ~}
 
-%{ if os_type == "centos" ~}
+%{ if os_distro == "centos" ~}
 yum_repos:
   docker:
     name: Docker CE Stable - $basearch
@@ -40,7 +40,7 @@ yum_repos:
     gpgcheck: true
     gpgkey: https://download.docker.com/linux/centos/gpg
 %{ endif ~}
-%{ if os_type == "ubuntu" ~}
+%{ if os_distro == "ubuntu" ~}
 apt:
   sources:
     docker.list:
@@ -52,17 +52,21 @@ apt:
 # yum/apt install the following packages
 #
 packages:
-%{ if os_type == "centos" ~}
+%{ if os_distro == "centos" ~}
   - epel-release
   - yum-utils
   - gcc-c++
   - java-11-openjdk-devel
+%{ if centos7  == "false" ~}
+  - java-17-openjdk-devel
+%{ endif ~}
   - git
 %{ endif ~}
-%{ if os_type == "ubuntu" ~}
+%{ if os_distro == "ubuntu" ~}
   - net-tools
   - g++
   - openjdk-11-jdk-headless
+  - openjdk-17-jdk
   - pdsh
   - pssh
   - make
@@ -79,17 +83,22 @@ runcmd:
 %{ endif ~}
   - mkdir -p ${software_root} ${zookeeper_dir} ${hadoop_dir} ${accumulo_dir}
   - chown hadoop.hadoop ${software_root} ${zookeeper_dir} ${hadoop_dir} ${accumulo_dir}
-%{ if os_type == "ubuntu" ~}
+%{ if os_distro == "ubuntu" ~}
   # Use bash instead of dash for the default shell
   - ln -s bash /bin/sh.bash
   - mv /bin/sh.bash /bin/sh
 %{ endif ~}
-%{ if os_type == "centos" ~}
+%{ if os_distro == "centos" ~}
   # This has to be done here vs in the packages section because
   # we install the epel-release package there and can't update
   # the yum repo in the middle to make it know about pdsh-mod-genders
   - yum -y update
   - yum -y install pdsh-mod-genders pssh
+%{ if centos7 == "true" ~}
+  - wget -O /tmp/jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz
+  - mkdir /usr/lib/jvm/java-17-openjdk
+  - tar zxf /tmp/jdk17.tar.gz --strip-components=1 -C /usr/lib/jvm/java-17-openjdk
+%{ endif ~}
 %{ endif ~}
   - sysctl -w vm.swappiness=0
   - sysctl -p
@@ -107,7 +116,7 @@ runcmd:
 write_files:
 # Set up PDSH to skip strict host key checking. Also, on ubuntu, we need
 # to set ssh as the default method for the rcmd module.
-%{ if os_type == "ubuntu" ~}
+%{ if os_distro == "ubuntu" ~}
   - path: /etc/pdsh/rcmd_default
     permissions: '0644'
     content: |

--- a/contrib/terraform-testing-infrastructure/modules/config-files/main.tf
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/main.tf
@@ -17,9 +17,7 @@
 # under the License.
 #
 
-variable "os_type" {
-  default = "centos"
-}
+variable "os_distro" {}
 variable "software_root" {}
 variable "upload_host" {}
 variable "manager_ip" {}
@@ -56,14 +54,16 @@ locals {
   files_dir     = "${path.module}/files"
   templates_dir = "${path.module}/templates"
 
-  java_home        = var.os_type == "ubuntu" ? "/usr/lib/jvm/java-11-openjdk-amd64" : "/usr/lib/jvm/java-11-openjdk"
+  java_11_home        = var.os_distro == "ubuntu" ? "/usr/lib/jvm/java-11-openjdk-amd64" : "/usr/lib/jvm/java-11-openjdk"
+  java_17_home        = var.os_distro == "ubuntu" ? "/usr/lib/jvm/java-17-openjdk-amd64" : "/usr/lib/jvm/java-17-openjdk"
   accumulo_root_pw = coalesce(var.accumulo_root_password, random_string.accumulo_root_password.result)
 
   template_vars = {
-    os_type                      = var.os_type
+    os_distro                    = var.os_distro
     manager_ip                   = var.manager_ip
     worker_ips                   = var.worker_ips
-    java_home                    = local.java_home
+    java_11_home                 = local.java_11_home
+    java_17_home                 = local.java_17_home
     accumulo_branch_name         = var.accumulo_branch_name
     accumulo_dir                 = var.accumulo_dir
     accumulo_repo                = var.accumulo_repo

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop-datanode.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop-datanode.service.tftpl
@@ -22,7 +22,7 @@ Description=Hadoop DataNode start/stop
 After=remote-fs.target
 
 [Service]
-Environment=JAVA_HOME=${java_home}
+Environment=JAVA_HOME=${java_11_home}
 Environment=HADOOP_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
 Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
 User=hadoop

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop-namenode.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop-namenode.service.tftpl
@@ -22,7 +22,7 @@ Description=Hadoop NameNode start/stop
 After=remote-fs.target
 
 [Service]
-Environment=JAVA_HOME=${java_home}
+Environment=JAVA_HOME=${java_11_home}
 Environment=HADOOP_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
 Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
 User=hadoop

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop_bashrc.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/hadoop_bashrc.tftpl
@@ -2,14 +2,14 @@
 if [ -f /etc/bashrc ]; then
   source /etc/bashrc
 fi
-export JAVA_HOME=${java_home}
+export JAVA_HOME=${java_11_home}
 export ZOOKEEPER_HOME=${software_root}/zookeeper/apache-zookeeper-${zookeeper_version}-bin
 export HADOOP_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
 export ACCUMULO_HOME=${software_root}/accumulo/accumulo-${accumulo_version}
 export ACCUMULO_LOG_DIR=${accumulo_dir}/logs
 export M2_HOME=${software_root}/apache-maven/apache-maven-${maven_version}
 
-export ACCUMULO_JAVA_OPTS="-javaagent:${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.19.0.jar -Dotel.traces.exporter=jaeger -Dotel.metrics.exporter=none -Dotel.logs.exporter=none -Dotel.exporter.jaeger.endpoint=http://${manager_ip}:14250 -Dtest.meter.registry.host=${manager_ip} -Dtest.meter.registry.port=8125"
+export ACCUMULO_JAVA_OPTS="-javaagent:${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.32.0.jar -Dotel.traces.exporter=jaeger -Dotel.metrics.exporter=none -Dotel.logs.exporter=none -Dotel.exporter.jaeger.endpoint=http://${manager_ip}:14250 -Dtest.meter.registry.host=${manager_ip} -Dtest.meter.registry.port=8125"
 
 # User specific environment and startup programs
 PATH=$PATH:$HOME/.local/bin:$HOME/bin:$ZOOKEEPER_HOME/bin:$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$ACCUMULO_HOME/bin:$M2_HOME/bin

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_accumulo.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/initialize_accumulo.sh.tftpl
@@ -33,10 +33,10 @@ accumulo init --instance-name "$1" --password "$2"
 #
 # Launch jaegertracing and telegraf containers
 #
-%{ if os_type == "centos" ~}
+%{ if os_distro == "centos" ~}
 sudo yum install -y docker-ce docker-ce-cli containerd.io --enablerepo=docker
 %{ endif ~}
-%{ if os_type == "ubuntu" ~}
+%{ if os_distro == "ubuntu" ~}
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 %{ endif ~}
 sudo systemctl enable docker

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -20,7 +20,7 @@
 
 set -eo pipefail
 
-export JAVA_HOME=${java_home}
+export JAVA_HOME=${java_11_home}
 
 SOURCES_DIR="${software_root}/sources"
 
@@ -94,7 +94,14 @@ else
   git clone ${accumulo_repo} accumulo-repo
   cd accumulo-repo
   git checkout ${accumulo_branch_name}
+  # Java 17 required for Accumulo build
+  OLDPATH="$PATH"
+  export JAVA_HOME=${java_17_home}
+  export PATH=$JAVA_HOME/bin:$PATH
   ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean install -PskipQA
+  # Reset JAVA HOME to Java 11 for the remainder of the script
+  export JAVA_HOME=${java_11_home}
+  export PATH=$OLDPATH
   mkdir -p ${software_root}/accumulo
   tar zxf assemble/target/accumulo-${accumulo_version}-bin.tar.gz -C ${software_root}/accumulo
 fi
@@ -109,8 +116,8 @@ openssl rand -out ${software_root}/accumulo/accumulo-${accumulo_version}/conf/pe
 #
 # OpenTelemetry dependencies
 #
-if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.19.0.jar ]; then
-  wget https://search.maven.org/remotecontent?filepath=io/opentelemetry/javaagent/opentelemetry-javaagent/1.19.0/opentelemetry-javaagent-1.19.0.jar -O ${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.19.0.jar
+if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.32.0.jar ]; then
+  wget https://search.maven.org/remotecontent?filepath=io/opentelemetry/javaagent/opentelemetry-javaagent/1.32.0/opentelemetry-javaagent-1.32.0.jar -O ${software_root}/accumulo/accumulo-${accumulo_version}/lib/opentelemetry-javaagent-1.32.0.jar
 fi
 #
 # Micrometer dependencies
@@ -122,8 +129,8 @@ if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/accumulo-te
     echo "accumulo-test-${accumulo_version}.jar not found, metrics won't work..."
   fi
 fi
-if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.9.5.jar ]; then
-  wget https://search.maven.org/remotecontent?filepath=io/micrometer/micrometer-registry-statsd/1.9.5/micrometer-registry-statsd-1.9.5.jar -O ${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.9.5.jar
+if [ ! -f ${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.12.1.jar ]; then
+  wget https://search.maven.org/remotecontent?filepath=io/micrometer/micrometer-registry-statsd/1.12.1/micrometer-registry-statsd-1.12.1.jar -O ${software_root}/accumulo/accumulo-${accumulo_version}/lib/micrometer-registry-statsd-1.12.1.jar
 fi
 
 #

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-nodemanager.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-nodemanager.service.tftpl
@@ -22,7 +22,7 @@ Description=Yarn NodeManager start/stop
 After=hadoop-datanode.service
 
 [Service]
-Environment=JAVA_HOME=${java_home}
+Environment=JAVA_HOME=${java_11_home}
 Environment=YARN_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
 Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
 User=hadoop

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-resourcemanager.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/yarn-resourcemanager.service.tftpl
@@ -22,7 +22,7 @@ Description=Yarn ResourceManager start/stop
 After=hadoop-namenode.service
 
 [Service]
-Environment=JAVA_HOME=${java_home}
+Environment=JAVA_HOME=${java_11_home}
 Environment=YARN_HOME=${software_root}/hadoop/hadoop-${hadoop_version}
 Environment=HADOOP_LOG_DIR=${hadoop_dir}/logs
 User=hadoop

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/zookeeper.service.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/zookeeper.service.tftpl
@@ -22,7 +22,7 @@ Description=ZooKeeper start/stop
 After=remote-fs.target
 
 [Service]
-Environment=JAVA_HOME=${java_home}
+Environment=JAVA_HOME=${java_11_home}
 Environment=ZOOKEEPER_HOME=${software_root}/zookeeper/apache-zookeeper-${zookeeper_version}-bin
 Environment=ZOO_LOG_DIR=${zookeeper_dir}/logs
 User=hadoop


### PR DESCRIPTION
This commit bumps the OpenTelemetry and Micrometer versions to match the versions in the current 2.1 branch pom.xml file. This also adds variables for os distribution and version to that special handling could be added to install both Java 11 and Java 17 (recent changes to Accumulo require Java 17 to build). Accumulo still uses Java 11 at runtime.