### PR TITLE
Fix deprecated props, use fluent-style threadpool builder

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
@@ -220,8 +220,8 @@ public class Module extends Node {
       fixture.setUp(state, env);
     }
 
-    ExecutorService service =
-        ThreadPools.getServerThreadPools().createFixedThreadPool(1, "RandomWalk Runner", false);
+    ExecutorService service = ThreadPools.getServerThreadPools().getPoolBuilder("RandomWalk Runner")
+        .numCoreThreads(1).build();
 
     try {
       Node initNode = getNode(initNodeId);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java
@@ -61,8 +61,8 @@ public class Setup extends Test {
     state.set("fs", FileSystem.get(env.getHadoopConfiguration()));
     state.set("bulkImportSuccess", "true");
     BulkPlusOne.counter.set(0L);
-    ThreadPoolExecutor e = ThreadPools.getServerThreadPools().createFixedThreadPool(MAX_POOL_SIZE,
-        "bulkImportPool", false);
+    ThreadPoolExecutor e = ThreadPools.getServerThreadPools().getPoolBuilder("bulkImportPool")
+        .numCoreThreads(MAX_POOL_SIZE).build();
     state.set("pool", e);
   }
 

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
@@ -65,6 +65,9 @@ public class Config extends Test {
   final Property TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS_deprecated =
       Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS;
 
+  @SuppressWarnings("deprecation")
+  final Property TSERV_WORKQ_THREADS_deprecated = Property.TSERV_WORKQ_THREADS;
+
   // @formatter:off
   final Setting[] settings = {
 			s(Property.TSERV_BLOOM_LOAD_MAXCONCURRENT, 1, 10),
@@ -89,7 +92,7 @@ public class Config extends Test {
 			s(Property.TSERV_WAL_SORT_BUFFER_SIZE, 1024 * 1024, 1024 * 1024 * 1024L),
 			s(Property.TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN, 5, 100),
 			s(Property.TSERV_WAL_BLOCKSIZE, 1024 * 1024,1024 * 1024 * 1024 * 10L),
-			s(Property.TSERV_WORKQ_THREADS, 1, 10),
+			s(TSERV_WORKQ_THREADS_deprecated, 1, 10),
 			s(Property.MANAGER_BULK_TIMEOUT, 10, 600),
 			s(Property.MANAGER_FATE_THREADPOOL_SIZE, 1, 100),
 			s(Property.MANAGER_RECOVERY_DELAY, 0, 100),


### PR DESCRIPTION
The changes in this PR fix deprecation errors in the build as long as implement the new fluent-style ThreadPool builder introduced in ec8ae122edfd5c25601694d107f18af014e28383.

Running `mvn clean verify` completes successfully on this branch, however when I try running `./bin/cingest createtable` I get the following errors and am not sure why:
```
[ERROR] /home/dgarguilo/github/accumulo-testing/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java:[223,65] cannot find symbol
[ERROR]   symbol:   method getPoolBuilder(java.lang.String)
[ERROR]   location: class org.apache.accumulo.core.util.threads.ThreadPools
[ERROR] /home/dgarguilo/github/accumulo-testing/src/main/java/org/apache/accumulo/testing/randomwalk/bulk/Setup.java:[64,62] cannot find symbol
[ERROR]   symbol:   method getPoolBuilder(java.lang.String)
[ERROR]   location: class org.apache.accumulo.core.util.threads.ThreadPools
```
It seems odd that this part fails with an error that I would imagine the main build would have caught. 