### PR TITLE
Fixes a few minor issues

### DIFF
--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/cluster.yaml.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/cluster.yaml.tftpl
@@ -58,5 +58,8 @@ compaction:
 # NUM_SSERVERS is set then it will override sservers_per_host.
 #
 tservers_per_host: 1
-sservers_per_host: 1
-
+sservers_per_host:
+ - default: 1
+compactors_per_host:
+ - q1: 1
+ - q2: 1

--- a/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
+++ b/contrib/terraform-testing-infrastructure/modules/config-files/templates/install_sw.sh.tftpl
@@ -150,7 +150,7 @@ else
   git clone ${accumulo_testing_repo} accumulo-testing-repo
   cd accumulo-testing-repo
   git checkout ${accumulo_testing_branch_name}
-  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean package -DskipTests -DskipITs
+  ${software_root}/apache-maven/apache-maven-${maven_version}/bin/mvn -ntp clean package -DskipTests -DskipITs -Daccumulo.version=${accumulo_version}
 fi
 
 #

--- a/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/CreateTable.java
@@ -108,6 +108,9 @@ public class CreateTable {
     String[] propArray = env.getTestProperty(propType).split(" ");
     Map<String,String> propMap = new HashMap<>();
     for (String prop : propArray) {
+      if (prop.isBlank()) {
+        continue;
+      }
       log.debug("prop: {}", prop);
       String[] kv = prop.split("=");
       propMap.put(kv[0], kv[1]);

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/concurrent/Config.java
@@ -69,6 +69,9 @@ public class Config extends Test {
   final Property TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN_deprecated =
       Property.TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN;
 
+  @SuppressWarnings("deprecation")
+  final Property TABLE_MINC_COMPACT_IDLETIME_deprecated = Property.TABLE_MINC_COMPACT_IDLETIME;
+
   // @formatter:off
   final Setting[] settings = {
 			s(Property.TSERV_BLOOM_LOAD_MAXCONCURRENT, 1, 10),
@@ -103,7 +106,7 @@ public class Config extends Test {
     final Setting[] tableSettings = {
 			s(Property.TABLE_MAJC_RATIO, 1, 10),
 			s(Property.TABLE_SPLIT_THRESHOLD, 10 * 1024, 10L * 1024 * 1024 * 1024),
-			s(Property.TABLE_MINC_COMPACT_IDLETIME, 100, 100 * 60 * 60 * 1000L),
+			s(TABLE_MINC_COMPACT_IDLETIME_deprecated, 100, 100 * 60 * 60 * 1000L),
 			s(Property.TABLE_SCAN_MAXMEM, 10 * 1024, 10 * 1024 * 1024),
 			s(Property.TABLE_FILE_COMPRESSED_BLOCK_SIZE, 10 * 1024, 10 * 1024 * 1024L),
 			s(Property.TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX, 10 * 1024, 10 * 1024 * 1024L),


### PR DESCRIPTION
Ran into a few problems when trying to run a small 2.1.4-SNAPSHOT cluster.  Fixed the following problems.

 * When build in accumulo-testing use the version of accumulo on the cluster.
 * Update the cluster yaml file to align with the latest changes in 2.1.3.
 * Handle a property that was recently deprecated in 3.1.0-SNAPSHOT.
 * Fix an issue with empty continuous ingest table config.