### PR TITLE
Replace call to ColumnVisibility.flatten() with getExpression()

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/continuous/ContinuousInputFormat.java
+++ b/src/main/java/org/apache/accumulo/testing/continuous/ContinuousInputFormat.java
@@ -143,8 +143,7 @@ public class ContinuousInputFormat extends InputFormat<Key,Value> {
 
         byte[] fam = genCol(random.nextInt(maxFam));
         byte[] qual = genCol(random.nextInt(maxQual));
-        @SuppressWarnings("deprecation")
-        byte[] cv = visibilities.get(random.nextInt(visibilities.size())).flatten();
+        byte[] cv = visibilities.get(random.nextInt(visibilities.size())).getExpression();
 
         if (cksum != null) {
           cksum.update(row);


### PR DESCRIPTION
`ColumnVisibility.flatten()` has been removed. This PR replaces it with `ColumnVisibility.getExpression()`