### PR TITLE
Correctly render Text output in randomwalk debug message

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/Module.java
@@ -44,7 +44,9 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.util.threads.ThreadPools;
+import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -354,7 +356,11 @@ public class Module extends Node {
               logMsg += value;
             else if (value instanceof byte[])
               logMsg += new String((byte[]) value, UTF_8);
-            else if (value instanceof PasswordToken)
+            else if (value instanceof Text) {
+              Text text = (Text) value;
+              logMsg +=
+                  Key.toPrintableString(text.getBytes(), 0, text.getLength(), text.getLength());
+            } else if (value instanceof PasswordToken)
               logMsg += new String(((PasswordToken) value).getPassword(), UTF_8);
             else
               logMsg += value.getClass() + " - " + value;


### PR DESCRIPTION
Fixes #217 

When an exception occurs during randomwalk, some state information gets displayed. Here is the output in question before these changes:
```
lastIndexRow: class org.apache.hadoop.io.Text - ���B_�5�ϷKoΤ�����
```
and after:
```
lastIndexRow: %ff;%de;%88;%9f;%95;y*o%82;%08;%0a;%e5;i,%dc;%cc;%ea;h%02;%d1;
```

These changes use Key.toPrintableString() to correctly render the Text object. This is the same way we handle this in the main accumulo repo.

To see this output, I ran `./bin/rwalk Image.xml` and deleted one of the tables that rwalk created which threw and exception and caused this state to be printed.