### PR TITLE
Fix Security randomwalk module

### DIFF
--- a/src/main/java/org/apache/accumulo/testing/randomwalk/security/SecurityFixture.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/security/SecurityFixture.java
@@ -64,7 +64,7 @@ public class SecurityFixture extends Fixture {
 
     WalkingSecurity.get(state, env).setTableName(secTableName);
     WalkingSecurity.get(state, env).setNamespaceName(secNamespaceName);
-    state.set("rootUserPass", env.getToken());
+    WalkingSecurity.get(state, env).setRootUserCredentials(client.whoami(), env.getToken());
 
     WalkingSecurity.get(state, env).setSysUserName(systemUserName);
     WalkingSecurity.get(state, env).createUser(systemUserName, sysUserPass);


### PR DESCRIPTION
Fixes #219 and #301 

This PR adds the following:
* captures and stores the root auth so when a part of the module is expected to fail, we can elevate permissions to do privileged actions when needed
* added timestamps for all permissions in WalkingSecurity so we can use the ambiguous check helper method for all cases
* added stronger checks to the bulk import cases and properly handle transient errors
* added the GET_SUMMARIES case to TableOp.java so we can run the module without getting a not implemented exception