### PR TITLE
Update accumulo version to 2.1.6 and other fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,15 +24,15 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>31</version>
+    <version>37</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-testing</artifactId>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.6-SNAPSHOT</version>
   <name>Apache Accumulo Testing</name>
   <description>Testing tools for Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.1.4</accumulo.version>
+    <accumulo.version>2.1.6</accumulo.version>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
     <maven.compiler.release>11</maven.compiler.release>

--- a/src/main/java/org/apache/accumulo/testing/randomwalk/shard/Merge.java
+++ b/src/main/java/org/apache/accumulo/testing/randomwalk/shard/Merge.java
@@ -39,7 +39,8 @@ public class Merge extends Test {
     log.debug("merging " + indexTableName);
     env.getAccumuloClient().tableOperations().merge(indexTableName, null, null);
     org.apache.accumulo.core.util.Merge merge = new org.apache.accumulo.core.util.Merge();
-    merge.mergomatic(env.getAccumuloClient(), indexTableName, null, null, 256 * 1024 * 1024, true);
+    merge.mergomatic(env.getAccumuloClient(), indexTableName, null, null, 256 * 1024 * 1024, true,
+        false);
     splits = env.getAccumuloClient().tableOperations().listSplits(indexTableName);
     if (splits.size() > splitSet.size()) {
       // throw an exception so that test will die and no further changes to table will occur...


### PR DESCRIPTION
* bump accumulo version from 2.1.4 -> 2.1.6
* change accumulo-testing version from 2.1.4-SNAPSHOT -> 2.1.6-SNAPSHOT
* bump parent pom version to 37 (same as accumulo 2.1.6)
* add missing param in merge method